### PR TITLE
✨ Initial AWS infrastructure setup with Terraform.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,9 @@ simulator/data
 
 simulator/*.png
 simulator/*.sh
+
+# terraform
+terraform/aws/.terraform/
+
+terraform.tfstate
+terraform.tfstate.*

--- a/terraform/aws/.terraform.lock.hcl
+++ b/terraform/aws/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.98.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:neMFK/kP1KT6cTGID+Tkkt8L7PsN9XqwrPDGXVw3WVY=",
+    "zh:23377bd90204b6203b904f48f53edcae3294eb072d8fc18a4531c0cde531a3a1",
+    "zh:2e55a6ea14cc43b08cf82d43063e96c5c2f58ee953c2628523d0ee918fe3b609",
+    "zh:4885a817c16fdaaeddc5031edc9594c1f300db0e5b23be7cd76a473e7dcc7b4f",
+    "zh:6ca7177ad4e5c9d93dee4be1ac0792b37107df04657fddfe0c976f36abdd18b5",
+    "zh:78bf8eb0a67bae5dede09666676c7a38c9fb8d1b80a90ba06cf36ae268257d6f",
+    "zh:874b5a99457a3f88e2915df8773120846b63d820868a8f43082193f3dc84adcb",
+    "zh:95e1e4cf587cde4537ac9dfee9e94270652c812ab31fce3a431778c053abf354",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a75145b58b241d64570803e6565c72467cd664633df32678755b51871f553e50",
+    "zh:aa31b13d0b0e8432940d6892a48b6268721fa54a02ed62ee42745186ee32f58d",
+    "zh:ae4565770f76672ce8e96528cbb66afdade1f91383123c079c7fdeafcb3d2877",
+    "zh:b99f042c45bf6aa69dd73f3f6d9cbe0b495b30442c526e0b3810089c059ba724",
+    "zh:bbb38e86d926ef101cefafe8fe090c57f2b1356eac9fc5ec81af310c50375897",
+    "zh:d03c89988ba4a0bd3cfc8659f951183ae7027aa8018a7ca1e53a300944af59cb",
+    "zh:d179ef28843fe663fc63169291a211898199009f0d3f63f0a6f65349e77727ec",
+  ]
+}

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -1,0 +1,36 @@
+# VPC 생성
+resource "aws_vpc" "main" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = {
+    Name        = "${var.project_name}-vpc"
+    Environment = var.environment
+  }
+}
+
+# 서브넷 생성
+resource "aws_subnet" "public" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = "10.0.1.0/24"
+  availability_zone       = "${var.aws_region}a"
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name        = "${var.project_name}-public-subnet"
+    Environment = var.environment
+  }
+}
+
+# EC2 인스턴스 생성
+resource "aws_instance" "web" {
+  ami           = "ami-0a93a08544874b3b7" # Amazon Linux 2 AMI (리전에 따라 변경 필요)
+  instance_type = "t2.micro"
+  subnet_id     = aws_subnet.public.id
+  
+  tags = {
+    Name        = "${var.project_name}-web-server"
+    Environment = var.environment
+  }
+}

--- a/terraform/aws/outputs.tf
+++ b/terraform/aws/outputs.tf
@@ -1,0 +1,11 @@
+output "vpc_id" {
+  value = aws_vpc.main.id
+}
+
+output "instance_id" {
+  value = aws_instance.web.id
+}
+
+output "instance_public_ip" {
+  value = aws_instance.web.public_ip
+}

--- a/terraform/aws/providers.tf
+++ b/terraform/aws/providers.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0" # AWS 프로바이더의 버전은 5.x를 사용
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -1,0 +1,14 @@
+variable "aws_region" {
+  description = "AWS 리전"
+  default     = "ap-northeast-2" # 서울 리전
+}
+
+variable "project_name" {
+  description = "사용자 지정 프로젝트 이름"
+  default     = "fleecy-cloud"
+}
+
+variable "environment" {
+  description = "환경 (dev, staging, prod)"
+  default     = "dev"
+}


### PR DESCRIPTION
# 구현 사항
- Terraform IaC approach를 이용하여 기본적은 aws infrastructure을 만들었습니다.

# 실행 방법
## 1. terraform 설치, aws cli 설치
mac 기준
```
brew install terraform
brew install awscli
```

## 2. aws configure
### 2-1. access key 생성
<img width="1227" alt="image" src="https://github.com/user-attachments/assets/d4ac6743-cccc-415b-9cf6-ecd3c724ee22" />

### 2-2. aws configure

```
aws configure
> AWS Access Key ID [None]: (키 입력)
> AWS Secret Access Key [None]: (비밀번호 입력)
> Default region name [None]: ap-northeast-2
> Default output format [None]: json
```

### 2-3. terraform 명령어 수행

```
cd terraform/aws
terraform init
terraform plan
terraform apply

# 작업 후
terraform destroy
```

# 3. 실행 결과
<img width="1214" alt="image" src="https://github.com/user-attachments/assets/cc834a4b-0bab-4be7-b957-40d80d226b9d" />
<img width="250" alt="image" src="https://github.com/user-attachments/assets/0f66a672-55c9-4efd-8134-be0ac6f2f6ba" />
<img width="293" alt="image" src="https://github.com/user-attachments/assets/39c4fad7-503a-4772-9ebf-33fd1dfbe0fb" />
<img width="500" alt="image" src="https://github.com/user-attachments/assets/8d079d62-2786-4105-8385-569f374bd67f" />

# 4. 파일 설명
- providers.tf: 클라우드 제공업체 정의 파일
   - 이 때 AWS 자격 증명(액세스 키, 시크릿 키)은 aws configure로 이미 설정한 값을 자동으로 사용
- variables.tf: 변수 정의
- main.tf: 리소스 생성
- outputs.tf: 출력 값 정의