### PR TITLE
✨ feat: enhance healthcheck result display with detailed infornation

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -97,6 +97,6 @@ require (
 	golang.org/x/sys v0.33.0 // indirect
 	golang.org/x/text v0.25.0 // indirect
 	google.golang.org/protobuf v1.36.6 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect; direct
+	gopkg.in/yaml.v3 v3.0.1 // direct
 	gorm.io/gorm v1.26.1
 )

--- a/backend/handlers/participant_handler.go
+++ b/backend/handlers/participant_handler.go
@@ -128,7 +128,7 @@ func (h *ParticipantHandler) CreateParticipant(c *gin.Context) {
 		return
 	}
 
-	// 연결 테스트 성공 시 자동으로 활성화
+	// 연결 테스트 성공 시 활성화
 	participant.Status = "active"
 
 	// 테스트 성공 시 DB에 저장
@@ -358,11 +358,11 @@ func (h *ParticipantHandler) HealthCheckParticipant(c *gin.Context) {
 	
 	healthy := err == nil
 	status := "ACTIVE"
-	message := "OpenStack 클라우드가 정상적으로 연결되었습니다"
+	message := fmt.Sprintf("%s 클러스터가 정상적으로 연결되었습니다", participant.Name)
 	
 	if !healthy {
 		status = "ERROR"
-		message = fmt.Sprintf("OpenStack 연결 실패: %v", err)
+		message = fmt.Sprintf("%s OpenStack 연결 실패: %v", participant.Name, err)
 	}
 
 	result := map[string]interface{}{

--- a/backend/services/openstack_service.go
+++ b/backend/services/openstack_service.go
@@ -104,9 +104,8 @@ func (s *OpenStackService) GetAuthToken(participant *models.Participant) (string
 			ID:     participant.OpenStackApplicationCredentialID,
 			Secret: participant.OpenStackApplicationCredentialSecret,
 		}
-		// Application Credential 방식에서는 scope가 필요하지 않음
 	} else {
-		return "", fmt.Errorf("Application Credential 인증 정보가 필요합니다")
+		return "", fmt.Errorf("application Credential 인증 정보가 필요합니다")
 	}
 
 	jsonData, err := json.Marshal(authReq)

--- a/frontend/src/components/dashboard/participants/participants-content.tsx
+++ b/frontend/src/components/dashboard/participants/participants-content.tsx
@@ -235,11 +235,54 @@ export default function ParticipantsContent() {
 	// VM 헬스체크
 	const handleHealthCheck = async (participant: Participant) => {
 		try {
-			await healthCheckVM(participant.id);
-			toast.success("헬스체크가 완료되었습니다.");
+			const healthResult = await healthCheckVM(participant.id);
+
+			// 상세한 헬스체크 결과 표시
+			if (healthResult.healthy) {
+				toast.success(
+					<div className="space-y-1">
+						<div className="font-semibold">
+							✅ {participant.name} 헬스체크 성공
+						</div>
+						<div className="text-sm">상태: {healthResult.status}</div>
+						<div className="text-sm">
+							응답시간: {healthResult.response_time_ms}ms
+						</div>
+						<div className="text-sm">{healthResult.message}</div>
+					</div>,
+					{
+						duration: 5000,
+					}
+				);
+			} else {
+				toast.error(
+					<div className="space-y-1">
+						<div className="font-semibold">
+							❌ {participant.name} 헬스체크 실패
+						</div>
+						<div className="text-sm">상태: {healthResult.status}</div>
+						<div className="text-sm">
+							응답시간: {healthResult.response_time_ms}ms
+						</div>
+						<div className="text-sm">{healthResult.message}</div>
+					</div>,
+					{
+						duration: 8000,
+					}
+				);
+			}
 		} catch (error) {
 			console.error("헬스체크 실패:", error);
-			toast.error("헬스체크에 실패했습니다.");
+			toast.error(
+				<div className="space-y-1">
+					<div className="font-semibold">
+						🚨 {participant.name} 헬스체크 오류
+					</div>
+					<div className="text-sm">
+						{error instanceof Error ? error.message : String(error)}
+					</div>
+				</div>
+			);
 		}
 	};
 


### PR DESCRIPTION
### What's changed:
- Updated backend health check response to include participant names
- Added structured JSX toast components for better readability
- Displayed participant name, status, and response time in UI

### Components update:
- participant management page -  toast
- participant handler - response message

### toast example
- Health Check Failed
![스크린샷 2025-06-04 154524](https://github.com/user-attachments/assets/35584532-b3a5-4cb3-aa75-9700ddf938a5)

- Health Check Successed
![스크린샷 2025-06-04 153250](https://github.com/user-attachments/assets/7d2b90c2-3590-43ac-8e9e-716269f7a044)
