### PR TITLE
✨ AWS infrastructure setup with Terraform.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ simulator/*.sh
 
 # terraform
 terraform/aws/.terraform/
+terraform/gcp/.terraform/
 
 terraform.tfstate
 terraform.tfstate.*

--- a/terraform/common/scripts/setup-monitoring.sh
+++ b/terraform/common/scripts/setup-monitoring.sh
@@ -85,25 +85,23 @@ EOF
 # 9. Grafana sample dashboard (JSON)
 cat <<'EOF' > /opt/monitoring/grafana/provisioning/dashboards/sample-dashboard.json
 {
-  "dashboard": {
-    "id": null,
-    "title": "Sample Monitoring Dashboard",
-    "panels": [
-      {
-        "type": "graph",
-        "title": "Node Exporter CPU Usage",
-        "targets": [
-          {
-            "expr": "rate(node_cpu_seconds_total[1m])",
-            "legendFormat": "{{cpu}}"
-          }
-        ],
-        "datasource": "Prometheus"
-      }
-    ],
-    "schemaVersion": 16,
-    "version": 0
-  }
+  "id": null,
+  "title": "Sample Monitoring Dashboard",
+  "panels": [
+    {
+      "type": "graph",
+      "title": "Node Exporter CPU Usage",
+      "targets": [
+        {
+          "expr": "rate(node_cpu_seconds_total[1m])",
+          "legendFormat": "{{cpu}}"
+        }
+      ],
+      "datasource": "Prometheus"
+    }
+  ],
+  "schemaVersion": 16,
+  "version": 0
 }
 EOF
 

--- a/terraform/gcp/.terraform.lock.hcl
+++ b/terraform/gcp/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "4.85.0"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:ZVDZuhYSIWhCkSuDkwFeSIJjn0/DcCxak2W/cHW4OQQ=",
+    "zh:17d60a6a6c1741cf1e09ac6731433a30950285eac88236e623ab4cbf23832ca3",
+    "zh:1c70254c016439dbb75cab646b4beace6ceeff117c75d81f2cc27d41c312f752",
+    "zh:35e2aa2cc7ac84ce55e05bb4de7b461b169d3582e56d3262e249ff09d64fe008",
+    "zh:417afb08d7b2744429f6b76806f4134d62b0354acf98e8a6c00de3c24f2bb6ad",
+    "zh:622165d09d21d9a922c86f1fc7177a400507f2a8c4a4513114407ae04da2dd29",
+    "zh:7cdb8e39a8ea0939558d87d2cb6caceded9e21f21003d9e9f9ce648d5db0bc3a",
+    "zh:851e737dc551d6004a860a8907fda65118fc2c7ede9fa828f7be704a2a39e68f",
+    "zh:a331ad289a02a2c4473572a573dc389be0a604cdd9e03dd8dbc10297fb14f14d",
+    "zh:b67fd531251380decd8dd1f849460d60f329f89df3d15f5815849a1dd001f430",
+    "zh:be8785957acca4f97aa3e800b313b57d1fca07788761c8867c9bc701fbe0bdb5",
+    "zh:cb6579a259fe020e1f88217d8f6937b2d5ace15b6406370977a1966eb31b1ca5",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/terraform/gcp/deploy.sh
+++ b/terraform/gcp/deploy.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+
+# GCP Terraform 배포 스크립트
+
+set -e  # 에러 발생시 스크립트 중단
+
+# 색상 정의
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# 로그 함수
+log_info() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+log_warn() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# 사용법 출력
+usage() {
+    echo "사용법: $0 [COMMAND] [OPTIONS]"
+    echo ""
+    echo "COMMANDS:"
+    echo "  init     - Terraform 초기화"
+    echo "  plan     - 실행 계획 확인"
+    echo "  apply    - 인프라 배포"
+    echo "  destroy  - 인프라 삭제"
+    echo "  output   - 출력 값 확인"
+    echo ""
+    echo "OPTIONS:"
+    echo "  -e, --env ENV     환경 설정 (dev, prod) [기본값: dev]"
+    echo "  -p, --project ID  GCP 프로젝트 ID"
+    echo "  -h, --help        도움말 출력"
+    echo ""
+    echo "예시:"
+    echo "  $0 init --project my-gcp-project"
+    echo "  $0 apply --env dev"
+    echo "  $0 destroy --env prod"
+}
+
+# 기본 값
+ENVIRONMENT="dev"
+PROJECT_ID=""
+COMMAND=""
+
+# 파라미터 파싱
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        init|plan|apply|destroy|output)
+            COMMAND="$1"
+            shift
+            ;;
+        -e|--env)
+            ENVIRONMENT="$2"
+            shift 2
+            ;;
+        -p|--project)
+            PROJECT_ID="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            log_error "알 수 없는 옵션: $1"
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+# 필수 파라미터 확인
+if [[ -z "$COMMAND" ]]; then
+    log_error "명령어를 지정해주세요."
+    usage
+    exit 1
+fi
+
+# GCP 인증 확인
+log_info "GCP 인증 상태 확인..."
+if ! gcloud auth list --filter=status:ACTIVE --format="value(account)" | grep -q .; then
+    log_error "GCP에 인증되지 않았습니다. 'gcloud auth login'을 실행하세요."
+    exit 1
+fi
+
+# 현재 프로젝트 확인
+CURRENT_PROJECT=$(gcloud config get-value project 2>/dev/null || echo "")
+if [[ -n "$PROJECT_ID" ]]; then
+    if [[ "$CURRENT_PROJECT" != "$PROJECT_ID" ]]; then
+        log_info "GCP 프로젝트를 $PROJECT_ID로 설정합니다..."
+        gcloud config set project "$PROJECT_ID"
+    fi
+elif [[ -z "$CURRENT_PROJECT" ]]; then
+    log_error "GCP 프로젝트가 설정되지 않았습니다. --project 옵션을 사용하거나 'gcloud config set project PROJECT_ID'를 실행하세요."
+    exit 1
+fi
+
+# 환경별 변수 파일 확인
+VAR_FILE="terraform.${ENVIRONMENT}.tfvars"
+if [[ ! -f "$VAR_FILE" ]]; then
+    log_warn "환경별 변수 파일 '$VAR_FILE'이 없습니다. terraform.tfvars를 사용합니다."
+    VAR_FILE="terraform.tfvars"
+fi
+
+if [[ ! -f "$VAR_FILE" ]]; then
+    log_error "변수 파일 '$VAR_FILE'이 없습니다. terraform.tfvars.example을 참고하여 작성하세요."
+    exit 1
+fi
+
+# Terraform 명령 실행
+case $COMMAND in
+    init)
+        log_info "Terraform을 초기화합니다..."
+        terraform init
+        ;;
+    plan)
+        log_info "Terraform 실행 계획을 확인합니다... (환경: $ENVIRONMENT)"
+        terraform plan -var-file="$VAR_FILE" -var="environment=$ENVIRONMENT"
+        ;;
+    apply)
+        log_info "인프라를 배포합니다... (환경: $ENVIRONMENT)"
+        terraform apply -var-file="$VAR_FILE" -var="environment=$ENVIRONMENT"
+        
+        if [[ $? -eq 0 ]]; then
+            log_info "배포가 완료되었습니다!"
+            echo ""
+            log_info "연결 정보:"
+            terraform output ssh_connection
+        fi
+        ;;
+    destroy)
+        log_warn "인프라를 삭제합니다... (환경: $ENVIRONMENT)"
+        echo "정말로 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+        read -p "계속하려면 'yes'를 입력하세요: " confirm
+        
+        if [[ "$confirm" == "yes" ]]; then
+            terraform destroy -var-file="$VAR_FILE" -var="environment=$ENVIRONMENT"
+        else
+            log_info "삭제가 취소되었습니다."
+        fi
+        ;;
+    output)
+        log_info "출력 값을 확인합니다..."
+        terraform output
+        ;;
+esac

--- a/terraform/gcp/main.tf
+++ b/terraform/gcp/main.tf
@@ -1,0 +1,170 @@
+# main.tf
+
+# Ubuntu 이미지 조회 (AWS AMI와 동일한 역할)
+data "google_compute_image" "ubuntu" {
+  family  = "ubuntu-2204-lts"
+  project = "ubuntu-os-cloud"
+}
+
+# VPC 네트워크 생성 (AWS VPC와 동일)
+resource "google_compute_network" "main" {
+  name                    = "${var.project_name}-vpc"
+  auto_create_subnetworks = false  # 수동으로 서브넷 생성
+  mtu                     = 1460
+}
+
+# 서브넷 생성 (AWS 퍼블릭 서브넷과 동일)
+resource "google_compute_subnetwork" "public" {
+  name          = "${var.project_name}-public-subnet"
+  ip_cidr_range = "10.0.1.0/24"
+  region        = var.region
+  network       = google_compute_network.main.id
+}
+
+# SSH 키 메타데이터 준비
+locals {
+  ssh_public_key = file(var.ssh_public_key_path)
+  ssh_keys = "${var.ssh_username}:${local.ssh_public_key}"
+}
+
+# 방화벽 규칙 - SSH (항상 필요)
+resource "google_compute_firewall" "ssh" {
+  name    = "${var.project_name}-allow-ssh"
+  network = google_compute_network.main.name
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+
+  source_ranges = var.allowed_ips
+  target_tags   = ["${var.project_name}-server"]
+
+  description = "Allow SSH access"
+}
+
+# 방화벽 규칙 - 개발 환경 (모든 TCP 포트)
+resource "google_compute_firewall" "dev_all_tcp" {
+  count = var.environment == "dev" ? 1 : 0
+  
+  name    = "${var.project_name}-allow-dev-all-tcp"
+  network = google_compute_network.main.name
+
+  allow {
+    protocol = "tcp"
+    ports    = ["1-65535"]
+  }
+
+  source_ranges = var.allowed_ips
+  target_tags   = ["${var.project_name}-server"]
+
+  description = "Allow all TCP ports for development"
+}
+
+# 방화벽 규칙 - HTTP/HTTPS (프로덕션)
+resource "google_compute_firewall" "web" {
+  count = var.environment != "dev" ? 1 : 0
+  
+  name    = "${var.project_name}-allow-web"
+  network = google_compute_network.main.name
+
+  allow {
+    protocol = "tcp"
+    ports    = ["80", "443"]
+  }
+
+  source_ranges = var.allowed_ips
+  target_tags   = ["${var.project_name}-server"]
+
+  description = "Allow HTTP and HTTPS"
+}
+
+# 방화벽 규칙 - 사용자 지정 포트들 (프로덕션)
+resource "google_compute_firewall" "custom_ports" {
+  count = var.environment != "dev" && length(var.custom_ports) > 0 ? 1 : 0
+  
+  name    = "${var.project_name}-allow-custom-ports"
+  network = google_compute_network.main.name
+
+  allow {
+    protocol = "tcp"
+    ports    = [for port in var.custom_ports : tostring(port)]
+  }
+
+  source_ranges = var.allowed_ips
+  target_tags   = ["${var.project_name}-server"]
+
+  description = "Allow custom ports"
+}
+
+# 방화벽 규칙 - 모니터링 포트들 (프로덕션)
+resource "google_compute_firewall" "monitoring" {
+  count = var.environment != "dev" ? 1 : 0
+  
+  name    = "${var.project_name}-allow-monitoring"
+  network = google_compute_network.main.name
+
+  allow {
+    protocol = "tcp"
+    ports    = ["9090", "3000", "16686"]  # Prometheus, Grafana, Jaeger
+  }
+
+  source_ranges = var.allowed_ips
+  target_tags   = ["${var.project_name}-server"]
+
+  description = "Allow monitoring ports"
+}
+
+# 컴퓨트 인스턴스 (AWS EC2와 동일)
+resource "google_compute_instance" "main" {
+  name         = "${var.project_name}-server"
+  machine_type = var.instance_type
+  zone         = var.zone
+
+  # 부팅 디스크 설정
+  boot_disk {
+    initialize_params {
+      image = data.google_compute_image.ubuntu.self_link
+      size  = 20  # GB
+      type  = "pd-standard"  # 표준 영구 디스크
+    }
+  }
+
+  # 네트워크 인터페이스
+  network_interface {
+    network    = google_compute_network.main.id
+    subnetwork = google_compute_subnetwork.public.id
+    
+    # 외부 IP 할당 (AWS의 map_public_ip_on_launch와 동일)
+    access_config {
+      // 빈 블록은 임시 외부 IP를 자동 할당
+    }
+  }
+
+  # 메타데이터 (SSH 키 포함)
+  metadata = {
+    ssh-keys = local.ssh_keys
+    startup-script = file("${path.module}/../common/scripts/setup-monitoring.sh")
+  }
+
+  # 네트워크 태그 (방화벽 규칙 적용을 위해)
+  tags = ["${var.project_name}-server"]
+
+  # 서비스 계정 (최소 권한)
+  service_account {
+    email  = google_service_account.vm_service_account.email
+    scopes = ["cloud-platform"]
+  }
+
+  labels = {
+    environment = var.environment
+    project     = var.project_name
+  }
+}
+
+# VM용 서비스 계정 생성
+resource "google_service_account" "vm_service_account" {
+  account_id   = "${var.project_name}-vm-sa"
+  display_name = "${var.project_name} VM Service Account"
+  description  = "Service account for ${var.project_name} VM instances"
+}

--- a/terraform/gcp/outputs.tf
+++ b/terraform/gcp/outputs.tf
@@ -1,0 +1,41 @@
+# outputs.tf
+
+output "instance_id" {
+  description = "생성된 인스턴스의 ID"
+  value       = google_compute_instance.main.id
+}
+
+output "instance_name" {
+  description = "생성된 인스턴스의 이름"
+  value       = google_compute_instance.main.name
+}
+
+output "external_ip" {
+  description = "인스턴스의 외부 IP 주소"
+  value       = google_compute_instance.main.network_interface[0].access_config[0].nat_ip
+}
+
+output "internal_ip" {
+  description = "인스턴스의 내부 IP 주소"
+  value       = google_compute_instance.main.network_interface[0].network_ip
+}
+
+output "vpc_network_name" {
+  description = "VPC 네트워크 이름"
+  value       = google_compute_network.main.name
+}
+
+output "subnet_name" {
+  description = "서브넷 이름"
+  value       = google_compute_subnetwork.public.name
+}
+
+output "ssh_connection" {
+  description = "SSH 연결 명령어"
+  value       = "ssh ${var.ssh_username}@${google_compute_instance.main.network_interface[0].access_config[0].nat_ip}"
+}
+
+output "zone" {
+  description = "인스턴스가 생성된 존"
+  value       = google_compute_instance.main.zone
+}

--- a/terraform/gcp/terraform.tfvars
+++ b/terraform/gcp/terraform.tfvars
@@ -1,0 +1,23 @@
+# GCP 프로젝트 설정
+project_id   = "fleecy-cloud"
+project_name = "fleecy-cloud"
+
+# 지역 설정 (gcp의 무료 요금제는 특정 리전에서만 가능)
+region = "us-central1"    # 무료 요금제 지원 리전
+zone   = "us-central1-a"  # 무료 요금제 지원 존
+
+# 환경 설정
+environment = "dev"  # dev 또는 prod
+
+# 인스턴스 설정
+instance_type = "f1-micro"  # aws t2.micro와 유사
+
+# 보안 설정
+allowed_ips = ["0.0.0.0/0"]  # 모든 IP에서 접근 허용 (개발용)
+
+# SSH 설정
+ssh_public_key_path = "~/.ssh/id_rsa.pub"
+ssh_username        = "ubuntu"
+
+# 프로덕션 환경용 포트 설정
+custom_ports = [8080, 9000, 5000]

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -1,0 +1,58 @@
+# variables.tf
+variable "project_id" {
+  description = "GCP 프로젝트 ID"
+  type        = string
+}
+
+variable "project_name" {
+  description = "프로젝트 이름 (리소스 명명에 사용)"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP 리전"
+  type        = string
+  default     = "asia-northeast3"  # 서울 리전
+}
+
+variable "zone" {
+  description = "GCP 존"
+  type        = string
+  default     = "asia-northeast3-a"  # 서울 존
+}
+
+variable "environment" {
+  description = "환경 (dev, prod)"
+  type        = string
+  default     = "dev"
+}
+
+variable "instance_type" {
+  description = "VM 인스턴스 타입"
+  type        = string
+  default     = "f1-micro"  # AWS t2.micro과 유사
+}
+
+variable "allowed_ips" {
+  description = "접근 허용할 IP CIDR 블록들"
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
+variable "custom_ports" {
+  description = "프로덕션 환경에서 허용할 사용자 지정 포트들"
+  type        = list(number)
+  default     = [8080, 9000]
+}
+
+variable "ssh_public_key_path" {
+  description = "SSH 공개키 파일 경로"
+  type        = string
+  default     = "~/.ssh/id_rsa.pub"
+}
+
+variable "ssh_username" {
+  description = "SSH 사용자명"
+  type        = string
+  default     = "ubuntu"
+}

--- a/terraform/gcp/versions.tf
+++ b/terraform/gcp/versions.tf
@@ -1,0 +1,18 @@
+# versions.tf
+terraform {
+  required_version = ">= 1.0"
+  
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.0"
+    }
+  }
+}
+
+# Provider 설정
+provider "google" {
+  project = var.project_id
+  region  = var.region
+  zone    = var.zone
+}


### PR DESCRIPTION
#10 #40 해당 PR들과 동일한 작업이 GCP에서도 가능하도록 했습니다.

## 초기 설정
### 1. gcp 설치
```brew install google-cloud-sdk```

### 2. 초기 설정
```
# 인증 및 초기 설정
gcloud init

# 또는 단계별로
gcloud auth login
gcloud config set project YOUR_PROJECT_ID
gcloud config set compute/region asia-northeast3
gcloud config set compute/zone asia-northeast3-a
```

## 배포 과정
```
chmod +x deploy.sh
./deploy.sh init --project fleecy-cloud
./deploy.sh plan --env dev
./deploy.sh apply --env dev
```

## 주요 차이점
- Internet Gateway 필요 없음

# 아직 쓰다 말았어요!!!! 이따 더 쓸게요