### PR TITLE
🎨 Seperate aggregator backend files.

### DIFF
--- a/backend/handlers/aggregator/handler.go
+++ b/backend/handlers/aggregator/handler.go
@@ -1,0 +1,191 @@
+package aggregator
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/Mungge/Fleecy-Cloud/services/aggregator"
+	"github.com/Mungge/Fleecy-Cloud/utils"
+	aggregatorvalidator "github.com/Mungge/Fleecy-Cloud/validators/aggregator"
+)
+
+// AggregatorHandler는 Aggregator 관련 API 핸들러입니다
+type AggregatorHandler struct {
+	aggregatorService   *aggregator.AggregatorService
+	metricsService      *aggregator.AggregatorMetricsService
+	trainingService     *aggregator.AggregatorTrainingService
+	optimizationService aggregator.OptimizationService
+}
+
+// NewAggregatorHandler는 새 AggregatorHandler 인스턴스를 생성합니다
+func NewAggregatorHandler(
+	aggregatorService *aggregator.AggregatorService,
+	metricsService *aggregator.AggregatorMetricsService,
+	trainingService *aggregator.AggregatorTrainingService,
+	optimizationService aggregator.OptimizationService,
+) *AggregatorHandler {
+	return &AggregatorHandler{
+		aggregatorService:   aggregatorService,
+		metricsService:      metricsService,
+		trainingService:     trainingService,
+		optimizationService: optimizationService,
+	}
+}
+
+// GetAggregators godoc
+// @Summary Aggregator 목록 조회
+// @Description 사용자의 모든 Aggregator 인스턴스를 조회합니다.
+// @Tags aggregators
+// @Accept json
+// @Produce json
+// @Success 200 {array} models.Aggregator
+// @Failure 401 {object} map[string]string
+// @Failure 500 {object} map[string]string
+// @Router /api/aggregators [get]
+func (h *AggregatorHandler) GetAggregators(c *gin.Context) {
+	userID, err := utils.GetUserIDFromContext(c)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "인증이 필요합니다"})
+		return
+	}
+
+	aggregators, err := h.aggregatorService.GetAggregatorsByUser(userID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Aggregator 목록 조회 실패"})
+		return
+	}
+
+	c.JSON(http.StatusOK, aggregators)
+}
+
+// GetAggregator godoc
+// @Summary 특정 Aggregator 조회
+// @Description ID로 특정 Aggregator를 조회합니다.
+// @Tags aggregators
+// @Accept json
+// @Produce json
+// @Param id path string true "Aggregator ID"
+// @Success 200 {object} models.Aggregator
+// @Failure 401 {object} map[string]string
+// @Failure 404 {object} map[string]string
+// @Failure 500 {object} map[string]string
+// @Router /api/aggregators/{id} [get]
+func (h *AggregatorHandler) GetAggregator(c *gin.Context) {
+	userID, err := utils.GetUserIDFromContext(c)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "인증이 필요합니다"})
+		return
+	}
+
+	id := c.Param("id")
+	aggregator, err := h.aggregatorService.GetAggregatorByID(id, userID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Aggregator 조회 실패"})
+		return
+	}
+
+	if aggregator == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Aggregator를 찾을 수 없습니다"})
+		return
+	}
+
+	c.JSON(http.StatusOK, aggregator)
+}
+
+// CreateAggregator godoc
+// @Summary 새 Aggregator 생성
+// @Description 새로운 Aggregator 인스턴스를 생성하고 Terraform으로 인프라를 배포합니다.
+// @Tags aggregators
+// @Accept json
+// @Produce json
+// @Param aggregator body CreateAggregatorRequest true "Aggregator 생성 정보"
+// @Success 201 {object} CreateAggregatorResponse
+// @Failure 400 {object} map[string]string
+// @Failure 401 {object} map[string]string
+// @Failure 500 {object} map[string]string
+// @Router /api/aggregators [post]
+func (h *AggregatorHandler) CreateAggregator(c *gin.Context) {
+	userID, err := utils.GetUserIDFromContext(c)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "인증이 필요합니다"})
+		return
+	}
+
+	var request CreateAggregatorRequest
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "잘못된 요청 형식입니다: " + err.Error()})
+		return
+	}
+
+	// 요청 데이터 검증
+	if err := aggregatorvalidator.ValidateCreateAggregatorRequest(
+		request.Name,
+		request.Algorithm,
+		request.Region,
+		request.Storage,
+		request.InstanceType,
+	); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	// 서비스 입력 구성
+	input := aggregator.CreateAggregatorInput{
+		Name:         request.Name,
+		Algorithm:    request.Algorithm,
+		Region:       request.Region,
+		Storage:      request.Storage,
+		InstanceType: request.InstanceType,
+		UserID:       userID,
+	}
+
+	// Aggregator 생성
+	result, err := h.aggregatorService.CreateAggregator(input)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Aggregator 생성 실패: " + err.Error()})
+		return
+	}
+
+	// 응답 반환
+	response := CreateAggregatorResponse{
+		AggregatorID:    result.AggregatorID,
+		Status:          result.Status,
+		TerraformStatus: result.TerraformStatus,
+	}
+
+	c.JSON(http.StatusCreated, gin.H{"data": response})
+}
+
+// DeleteAggregator godoc
+// @Summary Aggregator 삭제
+// @Description Aggregator를 삭제합니다.
+// @Tags aggregators
+// @Accept json
+// @Produce json
+// @Param id path string true "Aggregator ID"
+// @Success 200 {object} map[string]string
+// @Failure 401 {object} map[string]string
+// @Failure 404 {object} map[string]string
+// @Failure 500 {object} map[string]string
+// @Router /api/aggregators/{id} [delete]
+func (h *AggregatorHandler) DeleteAggregator(c *gin.Context) {
+	userID, err := utils.GetUserIDFromContext(c)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "인증이 필요합니다"})
+		return
+	}
+
+	id := c.Param("id")
+	
+	if err := h.aggregatorService.DeleteAggregator(id, userID); err != nil {
+		if err == aggregator.ErrAggregatorNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Aggregator를 찾을 수 없습니다"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Aggregator 삭제 실패"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "Aggregator가 삭제되었습니다"})
+}

--- a/backend/handlers/aggregator/metrices.go
+++ b/backend/handlers/aggregator/metrices.go
@@ -1,0 +1,132 @@
+package aggregator
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/Mungge/Fleecy-Cloud/services/aggregator"
+	"github.com/Mungge/Fleecy-Cloud/utils"
+	"github.com/Mungge/Fleecy-Cloud/validators/aggregator"
+)
+
+// UpdateAggregatorStatus godoc
+// @Summary Aggregator 상태 업데이트
+// @Description Aggregator의 상태를 업데이트합니다.
+// @Tags aggregators
+// @Accept json
+// @Produce json
+// @Param id path string true "Aggregator ID"
+// @Param status body UpdateStatusRequest true "상태 정보"
+// @Success 200 {object} map[string]string
+// @Failure 400 {object} map[string]string
+// @Failure 401 {object} map[string]string
+// @Failure 404 {object} map[string]string
+// @Failure 500 {object} map[string]string
+// @Router /api/aggregators/{id}/status [put]
+func (h *AggregatorHandler) UpdateAggregatorStatus(c *gin.Context) {
+	userID, err := utils.GetUserIDFromContext(c)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "인증이 필요합니다"})
+		return
+	}
+
+	id := c.Param("id")
+	
+	var request UpdateStatusRequest
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "잘못된 요청 형식입니다"})
+		return
+	}
+
+	// 요청 데이터 검증
+	if err := aggregatorvalidator.ValidateUpdateStatusRequest(request.Status); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	if err := h.metricsService.UpdateStatus(id, userID, request.Status); err != nil {
+		if err == aggregator.ErrAggregatorNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Aggregator를 찾을 수 없습니다"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "상태 업데이트 실패"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "상태가 업데이트되었습니다"})
+}
+
+// UpdateAggregatorMetrics godoc
+// @Summary Aggregator 메트릭 업데이트
+// @Description Aggregator의 실시간 메트릭을 업데이트합니다.
+// @Tags aggregators
+// @Accept json
+// @Produce json
+// @Param id path string true "Aggregator ID"
+// @Param metrics body UpdateMetricsRequest true "메트릭 정보"
+// @Success 200 {object} map[string]string
+// @Failure 400 {object} map[string]string
+// @Failure 401 {object} map[string]string
+// @Failure 404 {object} map[string]string
+// @Failure 500 {object} map[string]string
+// @Router /api/aggregators/{id}/metrics [put]
+func (h *AggregatorHandler) UpdateAggregatorMetrics(c *gin.Context) {
+	userID, err := utils.GetUserIDFromContext(c)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "인증이 필요합니다"})
+		return
+	}
+
+	id := c.Param("id")
+	
+	var request UpdateMetricsRequest
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "잘못된 요청 형식입니다"})
+		return
+	}
+
+	// 요청 데이터 검증
+	if err := aggregatorvalidator.ValidateUpdateMetricsRequest(request.CPUUsage, request.MemoryUsage, request.NetworkUsage); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	err = h.metricsService.UpdateMetrics(id, userID, request.CPUUsage, request.MemoryUsage, request.NetworkUsage)
+	if err != nil {
+		if err == aggregator.ErrAggregatorNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Aggregator를 찾을 수 없습니다"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "메트릭 업데이트 실패"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "메트릭이 업데이트되었습니다"})
+}
+
+// GetAggregatorStats godoc
+// @Summary Aggregator 통계 조회
+// @Description 사용자의 Aggregator 통계를 조회합니다.
+// @Tags aggregators
+// @Accept json
+// @Produce json
+// @Success 200 {object} map[string]interface{}
+// @Failure 401 {object} map[string]string
+// @Failure 500 {object} map[string]string
+// @Router /api/aggregators/stats [get]
+func (h *AggregatorHandler) GetAggregatorStats(c *gin.Context) {
+	userID, err := utils.GetUserIDFromContext(c)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "인증이 필요합니다"})
+		return
+	}
+
+	stats, err := h.metricsService.GetStats(userID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "통계 조회 실패"})
+		return
+	}
+
+	c.JSON(http.StatusOK, stats)
+}

--- a/backend/handlers/aggregator/optimization.go
+++ b/backend/handlers/aggregator/optimization.go
@@ -1,0 +1,80 @@
+package aggregator
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/Mungge/Fleecy-Cloud/services/aggregator"
+	"github.com/Mungge/Fleecy-Cloud/utils"
+	"github.com/Mungge/Fleecy-Cloud/validators/aggregator"
+)
+
+// OptimizeAggregatorPlacement godoc
+// @Summary 집계자 배치 최적화
+// @Description NSGA-II 알고리즘을 사용하여 사용자 제약사항에 맞는 최적의 집계자 배치 위치를 찾습니다.
+// @Tags aggregators
+// @Accept json
+// @Produce json
+// @Param request body aggregator.OptimizationRequest true "최적화 요청 정보"
+// @Success 200 {object} map[string]interface{} "data: aggregator.OptimizationResponse"
+// @Failure 400 {object} map[string]string "error: 잘못된 요청"
+// @Failure 401 {object} map[string]string "error: 인증 필요"
+// @Failure 500 {object} map[string]string "error: 서버 오류"
+// @Router /api/aggregators/optimization [post]
+func (h *AggregatorHandler) OptimizeAggregatorPlacement(c *gin.Context) {
+	// 1. 사용자 인증 확인
+	userID, err := utils.GetUserIDFromContext(c)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "인증이 필요합니다"})
+		return
+	}
+
+	// 2. 요청 데이터 파싱
+	var request aggregator.OptimizationRequest
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "잘못된 요청 형식입니다: " + err.Error(),
+		})
+		return
+	}
+
+	// 3. 요청 데이터 유효성 검증
+	if err := aggregatorvalidator.ValidateOptimizationRequest(&request); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "요청 데이터 유효성 검증 실패: " + err.Error(),
+		})
+		return
+	}
+
+	// 4. Python 환경 및 스크립트 존재 여부 확인
+	if err := h.optimizationService.ValidatePythonEnvironment(); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "Python 환경 오류: " + err.Error(),
+		})
+		return
+	}
+
+	if err := h.optimizationService.ValidatePythonScript(); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "Python 스크립트 오류: " + err.Error(),
+		})
+		return
+	}
+
+	// 5. 최적화 실행
+	result, err := h.optimizationService.RunOptimization(request)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "집계자 배치 최적화 실행 실패: " + err.Error(),
+		})
+		return
+	}
+
+	// 6. 성공 응답 반환
+	c.JSON(http.StatusOK, gin.H{
+		"message": "집계자 배치 최적화가 성공적으로 완료되었습니다",
+		"data":    result,
+		"userID":  userID, // 디버깅용 (필요에 따라 제거)
+	})
+}

--- a/backend/handlers/aggregator/training.go
+++ b/backend/handlers/aggregator/training.go
@@ -1,0 +1,44 @@
+package aggregator
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/Mungge/Fleecy-Cloud/services/aggregator"
+	"github.com/Mungge/Fleecy-Cloud/utils"
+)
+
+// GetTrainingHistory godoc
+// @Summary 학습 히스토리 조회
+// @Description Aggregator의 학습 히스토리를 조회합니다.
+// @Tags aggregators
+// @Accept json
+// @Produce json
+// @Param id path string true "Aggregator ID"
+// @Success 200 {array} models.TrainingRound
+// @Failure 401 {object} map[string]string
+// @Failure 404 {object} map[string]string
+// @Failure 500 {object} map[string]string
+// @Router /api/aggregators/{id}/training-history [get]
+func (h *AggregatorHandler) GetTrainingHistory(c *gin.Context) {
+	userID, err := utils.GetUserIDFromContext(c)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "인증이 필요합니다"})
+		return
+	}
+
+	id := c.Param("id")
+	
+	rounds, err := h.trainingService.GetTrainingHistory(id, userID)
+	if err != nil {
+		if err == aggregator.ErrAggregatorNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Aggregator를 찾을 수 없습니다"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "학습 히스토리 조회 실패"})
+		return
+	}
+
+	c.JSON(http.StatusOK, rounds)
+}

--- a/backend/handlers/aggregator/types.go
+++ b/backend/handlers/aggregator/types.go
@@ -1,0 +1,31 @@
+package aggregator
+
+// Request/Response structures
+
+// UpdateStatusRequest 상태 업데이트 요청
+type UpdateStatusRequest struct {
+	Status string `json:"status" binding:"required"`
+}
+
+// UpdateMetricsRequest 메트릭 업데이트 요청
+type UpdateMetricsRequest struct {
+	CPUUsage     float64 `json:"cpu_usage"`
+	MemoryUsage  float64 `json:"memory_usage"`
+	NetworkUsage float64 `json:"network_usage"`
+}
+
+// CreateAggregatorRequest Aggregator 생성 요청
+type CreateAggregatorRequest struct {
+	Name         string `json:"name" binding:"required"`
+	Algorithm    string `json:"algorithm" binding:"required"`
+	Region       string `json:"region" binding:"required"`
+	Storage      string `json:"storage" binding:"required"`
+	InstanceType string `json:"instanceType" binding:"required"`
+}
+
+// CreateAggregatorResponse Aggregator 생성 응답
+type CreateAggregatorResponse struct {
+	AggregatorID    string `json:"aggregatorId"`
+	Status          string `json:"status"`
+	TerraformStatus string `json:"terraformStatus,omitempty"`
+}

--- a/backend/handlers/aggregator_handler.go
+++ b/backend/handlers/aggregator_handler.go
@@ -1,595 +1,594 @@
 package handlers
 
-import (
-	"fmt"
-	"net/http"
-	"strings"
-	
-	"github.com/gin-gonic/gin"
-	"github.com/google/uuid"
-
-	"github.com/Mungge/Fleecy-Cloud/models"
-	"github.com/Mungge/Fleecy-Cloud/repository"
-	"github.com/Mungge/Fleecy-Cloud/services"
-	"github.com/Mungge/Fleecy-Cloud/utils"
-)
-
-// AggregatorHandler는 Aggregator 관련 API 핸들러입니다
-type AggregatorHandler struct {
-	repo   *repository.AggregatorRepository
-	flRepo *repository.FederatedLearningRepository
-	optimizationService *services.OptimizationService
-}
-
-// NewAggregatorHandler는 새 AggregatorHandler 인스턴스를 생성합니다
-func NewAggregatorHandler(repo *repository.AggregatorRepository, flRepo *repository.FederatedLearningRepository) *AggregatorHandler {
-	return &AggregatorHandler{
-		repo:   repo,
-		flRepo: flRepo,
-		optimizationService: services.NewOptimizationService(),
-	}
-}
-
-// OptimizeAggregatorPlacement godoc
-// @Summary 집계자 배치 최적화
-// @Description NSGA-II 알고리즘을 사용하여 사용자 제약사항에 맞는 최적의 집계자 배치 위치를 찾습니다.
-// @Tags aggregators
-// @Accept json
-// @Produce json
-// @Param request body services.OptimizationRequest true "최적화 요청 정보"
-// @Success 200 {object} map[string]interface{} "data: services.OptimizationResponse"
-// @Failure 400 {object} map[string]string "error: 잘못된 요청"
-// @Failure 401 {object} map[string]string "error: 인증 필요"
-// @Failure 500 {object} map[string]string "error: 서버 오류"
-// @Router /api/aggregator-placement-optimization [post]
-func (h *AggregatorHandler) OptimizeAggregatorPlacement(c *gin.Context) {
-	// 1. 사용자 인증 확인 (선택적 - 필요에 따라)
-	userID, err := utils.GetUserIDFromContext(c)
-	if err != nil {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "인증이 필요합니다"})
-		return
-	}
-
-	// 2. 요청 데이터 파싱
-	var request services.OptimizationRequest
-	if err := c.ShouldBindJSON(&request); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error": "잘못된 요청 형식입니다: " + err.Error(),
-		})
-		return
-	}
-
-	// 3. 요청 데이터 유효성 검증
-	if err := h.validateOptimizationRequest(&request); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error": "요청 데이터 유효성 검증 실패: " + err.Error(),
-		})
-		return
-	}
-
-	// 4. Python 환경 및 스크립트 존재 여부 확인
-	if err := h.optimizationService.ValidatePythonEnvironment(); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error": "Python 환경 오류: " + err.Error(),
-		})
-		return
-	}
-
-	if err := h.optimizationService.ValidatePythonScript(); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error": "Python 스크립트 오류: " + err.Error(),
-		})
-		return
-	}
-
-	// 5. 최적화 실행
-	result, err := h.optimizationService.RunOptimization(request)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error": "집계자 배치 최적화 실행 실패: " + err.Error(),
-		})
-		return
-	}
-
-	// 6. 성공 응답 반환
-	c.JSON(http.StatusOK, gin.H{
-		"message": "집계자 배치 최적화가 성공적으로 완료되었습니다",
-		"data":    result,
-		"userID":  userID, // 디버깅용 (필요에 따라 제거)
-	})
-}
-
-// validateOptimizationRequest 요청 데이터 유효성 검증
-func (h *AggregatorHandler) validateOptimizationRequest(request *services.OptimizationRequest) error {
-	// 1. 연합학습 정보 검증
-	if request.FederatedLearning.Name == "" {
-		return fmt.Errorf("연합학습 이름이 필요합니다")
-	}
-
-	if request.FederatedLearning.Algorithm == "" {
-		return fmt.Errorf("집계 알고리즘이 필요합니다")
-	}
-
-	if request.FederatedLearning.Rounds <= 0 {
-		return fmt.Errorf("라운드 수는 1 이상이어야 합니다")
-	}
-
-	// 2. 참여자 정보 검증
-	if len(request.FederatedLearning.Participants) == 0 {
-		return fmt.Errorf("최소 1명 이상의 참여자가 필요합니다")
-	}
-
-	for i, participant := range request.FederatedLearning.Participants {
-		if participant.ID == "" {
-			return fmt.Errorf("참여자 %d의 ID가 필요합니다", i+1)
-		}
-		if participant.Name == "" {
-			return fmt.Errorf("참여자 %d의 이름이 필요합니다", i+1)
-		}
-		if participant.OpenstackEndpoint == "" {
-			return fmt.Errorf("참여자 %d의 OpenStack 엔드포인트가 필요합니다", i+1)
-		}
-		// 간단한 URL 형식 검증
-		if !strings.HasPrefix(participant.OpenstackEndpoint, "http://") && 
-		   !strings.HasPrefix(participant.OpenstackEndpoint, "https://") {
-			return fmt.Errorf("참여자 %d의 OpenStack 엔드포인트가 올바른 URL 형식이 아닙니다", i+1)
-		}
-	}
-
-	// 3. 제약사항 검증
-	if request.AggregatorConfig.MaxBudget <= 0 {
-		return fmt.Errorf("최대 예산은 0보다 커야 합니다")
-	}
-
-	if request.AggregatorConfig.MaxLatency <= 0 {
-		return fmt.Errorf("최대 지연시간은 0보다 커야 합니다")
-	}
-
-	// 합리적인 범위 체크
-	if request.AggregatorConfig.MaxBudget > 10000000 { // 1천만원
-		return fmt.Errorf("최대 예산이 너무 큽니다 (최대: 10,000,000원)")
-	}
-
-	if request.AggregatorConfig.MaxLatency > 10000 { // 10초
-		return fmt.Errorf("최대 지연시간이 너무 큽니다 (최대: 10,000ms)")
-	}
-
-	return nil
-}
-
-
-// GetAggregators godoc
-// @Summary Aggregator 목록 조회
-// @Description 사용자의 모든 Aggregator 인스턴스를 조회합니다.
-// @Tags aggregators
-// @Accept json
-// @Produce json
-// @Success 200 {array} models.Aggregator
-// @Failure 401 {object} map[string]string
-// @Failure 500 {object} map[string]string
-// @Router /api/aggregators [get]
-func (h *AggregatorHandler) GetAggregators(c *gin.Context) {
-	userID, err := utils.GetUserIDFromContext(c)
-	if err != nil {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "인증이 필요합니다"})
-		return
-	}
-
-	aggregators, err := h.repo.GetAggregatorsByUserID(userID)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Aggregator 목록 조회 실패"})
-		return
-	}
-
-	c.JSON(http.StatusOK, aggregators)
-}
-
-// GetAggregator godoc
-// @Summary 특정 Aggregator 조회
-// @Description ID로 특정 Aggregator를 조회합니다.
-// @Tags aggregators
-// @Accept json
-// @Produce json
-// @Param id path string true "Aggregator ID"
-// @Success 200 {object} models.Aggregator
-// @Failure 401 {object} map[string]string
-// @Failure 404 {object} map[string]string
-// @Failure 500 {object} map[string]string
-// @Router /api/aggregators/{id} [get]
-func (h *AggregatorHandler) GetAggregator(c *gin.Context) {
-	userID, err := utils.GetUserIDFromContext(c)
-	if err != nil {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "인증이 필요합니다"})
-		return
-	}
-
-	id := c.Param("id")
-	aggregator, err := h.repo.GetAggregatorByID(id)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Aggregator 조회 실패"})
-		return
-	}
-
-	if aggregator == nil || aggregator.UserID != userID {
-		c.JSON(http.StatusNotFound, gin.H{"error": "Aggregator를 찾을 수 없습니다"})
-		return
-	}
-
-	c.JSON(http.StatusOK, aggregator)
-}
-
-// UpdateAggregatorStatus godoc
-// @Summary Aggregator 상태 업데이트
-// @Description Aggregator의 상태를 업데이트합니다.
-// @Tags aggregators
-// @Accept json
-// @Produce json
-// @Param id path string true "Aggregator ID"
-// @Param status body UpdateStatusRequest true "상태 정보"
-// @Success 200 {object} map[string]string
-// @Failure 400 {object} map[string]string
-// @Failure 401 {object} map[string]string
-// @Failure 404 {object} map[string]string
-// @Failure 500 {object} map[string]string
-// @Router /api/aggregators/{id}/status [put]
-func (h *AggregatorHandler) UpdateAggregatorStatus(c *gin.Context) {
-	userID, err := utils.GetUserIDFromContext(c)
-	if err != nil {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "인증이 필요합니다"})
-		return
-	}
-
-	id := c.Param("id")
-	
-	// 권한 확인
-	aggregator, err := h.repo.GetAggregatorByID(id)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Aggregator 조회 실패"})
-		return
-	}
-	if aggregator == nil || aggregator.UserID != userID {
-		c.JSON(http.StatusNotFound, gin.H{"error": "Aggregator를 찾을 수 없습니다"})
-		return
-	}
-
-	var request UpdateStatusRequest
-	if err := c.ShouldBindJSON(&request); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "잘못된 요청 형식입니다"})
-		return
-	}
-
-	if err := h.repo.UpdateAggregatorStatus(id, request.Status); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "상태 업데이트 실패"})
-		return
-	}
-
-	c.JSON(http.StatusOK, gin.H{"message": "상태가 업데이트되었습니다"})
-}
-
-// UpdateAggregatorMetrics godoc
-// @Summary Aggregator 메트릭 업데이트
-// @Description Aggregator의 실시간 메트릭을 업데이트합니다.
-// @Tags aggregators
-// @Accept json
-// @Produce json
-// @Param id path string true "Aggregator ID"
-// @Param metrics body UpdateMetricsRequest true "메트릭 정보"
-// @Success 200 {object} map[string]string
-// @Failure 400 {object} map[string]string
-// @Failure 401 {object} map[string]string
-// @Failure 404 {object} map[string]string
-// @Failure 500 {object} map[string]string
-// @Router /api/aggregators/{id}/metrics [put]
-func (h *AggregatorHandler) UpdateAggregatorMetrics(c *gin.Context) {
-	userID, err := utils.GetUserIDFromContext(c)
-	if err != nil {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "인증이 필요합니다"})
-		return
-	}
-
-	id := c.Param("id")
-	
-	// 권한 확인
-	aggregator, err := h.repo.GetAggregatorByID(id)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Aggregator 조회 실패"})
-		return
-	}
-	if aggregator == nil || aggregator.UserID != userID {
-		c.JSON(http.StatusNotFound, gin.H{"error": "Aggregator를 찾을 수 없습니다"})
-		return
-	}
-
-	var request UpdateMetricsRequest
-	if err := c.ShouldBindJSON(&request); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "잘못된 요청 형식입니다"})
-		return
-	}
-
-	err = h.repo.UpdateAggregatorMetrics(id, request.CPUUsage, request.MemoryUsage, request.NetworkUsage)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "메트릭 업데이트 실패"})
-		return
-	}
-
-	c.JSON(http.StatusOK, gin.H{"message": "메트릭이 업데이트되었습니다"})
-}
-
-// GetTrainingHistory godoc
-// @Summary 학습 히스토리 조회
-// @Description Aggregator의 학습 히스토리를 조회합니다.
-// @Tags aggregators
-// @Accept json
-// @Produce json
-// @Param id path string true "Aggregator ID"
-// @Success 200 {array} models.TrainingRound
-// @Failure 401 {object} map[string]string
-// @Failure 404 {object} map[string]string
-// @Failure 500 {object} map[string]string
-// @Router /api/aggregators/{id}/training-history [get]
-func (h *AggregatorHandler) GetTrainingHistory(c *gin.Context) {
-	userID, err := utils.GetUserIDFromContext(c)
-	if err != nil {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "인증이 필요합니다"})
-		return
-	}
-
-	id := c.Param("id")
-	
-	// 권한 확인
-	aggregator, err := h.repo.GetAggregatorByID(id)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Aggregator 조회 실패"})
-		return
-	}
-	if aggregator == nil || aggregator.UserID != userID {
-		c.JSON(http.StatusNotFound, gin.H{"error": "Aggregator를 찾을 수 없습니다"})
-		return
-	}
-
-	rounds, err := h.repo.GetTrainingRoundsByAggregatorID(id)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "학습 히스토리 조회 실패"})
-		return
-	}
-
-	c.JSON(http.StatusOK, rounds)
-}
-
-// GetAggregatorStats godoc
-// @Summary Aggregator 통계 조회
-// @Description 사용자의 Aggregator 통계를 조회합니다.
-// @Tags aggregators
-// @Accept json
-// @Produce json
-// @Success 200 {object} map[string]interface{}
-// @Failure 401 {object} map[string]string
-// @Failure 500 {object} map[string]string
-// @Router /api/aggregators/stats [get]
-func (h *AggregatorHandler) GetAggregatorStats(c *gin.Context) {
-	userID, err := utils.GetUserIDFromContext(c)
-	if err != nil {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "인증이 필요합니다"})
-		return
-	}
-
-	stats, err := h.repo.GetAggregatorStats(userID)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "통계 조회 실패"})
-		return
-	}
-
-	c.JSON(http.StatusOK, stats)
-}
-
-// DeleteAggregator godoc
-// @Summary Aggregator 삭제
-// @Description Aggregator를 삭제합니다.
-// @Tags aggregators
-// @Accept json
-// @Produce json
-// @Param id path string true "Aggregator ID"
-// @Success 200 {object} map[string]string
-// @Failure 401 {object} map[string]string
-// @Failure 404 {object} map[string]string
-// @Failure 500 {object} map[string]string
-// @Router /api/aggregators/{id} [delete]
-func (h *AggregatorHandler) DeleteAggregator(c *gin.Context) {
-	userID, err := utils.GetUserIDFromContext(c)
-	if err != nil {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "인증이 필요합니다"})
-		return
-	}
-
-	id := c.Param("id")
-	
-	// 권한 확인
-	aggregator, err := h.repo.GetAggregatorByID(id)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Aggregator 조회 실패"})
-		return
-	}
-	if aggregator == nil || aggregator.UserID != userID {
-		c.JSON(http.StatusNotFound, gin.H{"error": "Aggregator를 찾을 수 없습니다"})
-		return
-	}
-
-	if err := h.repo.DeleteAggregator(id); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Aggregator 삭제 실패"})
-		return
-	}
-
-	c.JSON(http.StatusOK, gin.H{"message": "Aggregator가 삭제되었습니다"})
-}
-
-
-// CreateAggregator godoc
-// @Summary 새 Aggregator 생성
-// @Description 새로운 Aggregator 인스턴스를 생성하고 Terraform으로 인프라를 배포합니다.
-// @Tags aggregators
-// @Accept json
-// @Produce json
-// @Param aggregator body CreateAggregatorRequest true "Aggregator 생성 정보"
-// @Success 201 {object} CreateAggregatorResponse
-// @Failure 400 {object} map[string]string
-// @Failure 401 {object} map[string]string
-// @Failure 500 {object} map[string]string
-// @Router /api/aggregators [post]
-func (h *AggregatorHandler) CreateAggregator(c *gin.Context) {
-	userID, err := utils.GetUserIDFromContext(c)
-	if err != nil {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "인증이 필요합니다"})
-		return
-	}
-
-	var request CreateAggregatorRequest
-	if err := c.ShouldBindJSON(&request); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "잘못된 요청 형식입니다: " + err.Error()})
-		return
-	}
-
-	// Aggregator 생성
-	aggregator := &models.Aggregator{
-		ID:            uuid.New().String(),
-		UserID:       userID,
-		Name:         request.Name,
-		Status:       "creating",
-		Algorithm:    request.Algorithm,
-		CloudProvider: "openstack",
-		Region:       request.Region,
-		InstanceType: request.InstanceType,
-		StorageSpecs: request.Storage + "GB",
-	}
-
-	// DB에 저장
-	if err := h.repo.CreateAggregator(aggregator); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Aggregator 생성 실패: " + err.Error()})
-		return
-	}
-
-	// Terraform 배포 시작 (비동기)
-	go func() {
-		if err := h.deployWithTerraform(aggregator); err != nil {
-			aggregator.Status = "failed"
-			h.repo.UpdateAggregator(aggregator)
-			return
-		}
-		aggregator.Status = "running"
-		h.repo.UpdateAggregator(aggregator)
-	}()
-
-	// 응답 반환
-	response := CreateAggregatorResponse{
-		AggregatorID:    aggregator.ID,
-		Status:          "creating",
-		TerraformStatus: "deploying",
-	}
-
-	c.JSON(http.StatusCreated, gin.H{"data": response})
-}
-
-// deployWithTerraform은 Terraform을 사용하여 인프라를 배포합니다
-func (h *AggregatorHandler) deployWithTerraform(aggregator *models.Aggregator) error {
-	// Terraform 설정 생성
-	config := utils.TerraformConfig{
-		Region:       aggregator.Region,
-		InstanceType: aggregator.InstanceType,
-		ProjectName:  "fleecy-aggregator",
-		Environment:  "production",
-	}
-	
-	// Terraform 작업공간 생성
-	workspaceDir, err := utils.CreateTerraformWorkspace(aggregator.ID, config)
-	if err != nil {
-		return err
-	}
-	
-	// Terraform 배포 실행
-	result, err := utils.DeployWithTerraform(workspaceDir)
-	if err != nil {
-		return err
-	}
-	
-	// 배포 결과를 aggregator에 저장
-	aggregator.InstanceID = result.InstanceID
-	aggregator.Status = "running"
-	if aggregator.Configuration == nil {
-		aggregator.Configuration = make(map[string]interface{})
-	}
-	aggregator.Configuration["public_ip"] = result.PublicIP
-	aggregator.Configuration["private_ip"] = result.PrivateIP
-	aggregator.Configuration["workspace_dir"] = result.WorkspaceDir
-	
-	return nil
-}
-
-
-// Request/Response structures
-type UpdateStatusRequest struct {
-	Status string `json:"status" binding:"required"`
-}
-
-type UpdateMetricsRequest struct {
-	CPUUsage     float64 `json:"cpu_usage"`
-	MemoryUsage  float64 `json:"memory_usage"`
-	NetworkUsage float64 `json:"network_usage"`
-}
-
-// Aggregator 생성 요청 구조
-type CreateAggregatorRequest struct {
-	Name         string `json:"name" binding:"required"`
-	Algorithm    string `json:"algorithm" binding:"required"`
-	Region       string `json:"region" binding:"required"`
-	Storage      string `json:"storage" binding:"required"`
-	InstanceType string `json:"instanceType" binding:"required"`
-}
-
-// Aggregator 생성 응답 구조
-type CreateAggregatorResponse struct {
-	AggregatorID    string `json:"aggregatorId"`
-	Status          string `json:"status"`
-	TerraformStatus string `json:"terraformStatus,omitempty"`
-}
-
-// 프론트엔드에서 오는 연합학습 데이터 구조 (통합 생성용)
-type FederatedLearningData struct {
-	Name         string `json:"name"`
-	Description  string `json:"description"`
-	ModelType    string `json:"modelType"`
-	Algorithm    string `json:"algorithm"`
-	Rounds       int    `json:"rounds"`
-	Participants []struct {
-		ID                string `json:"id"`
-		Name              string `json:"name"`
-		Status            string `json:"status"`
-		OpenstackEndpoint string `json:"openstack_endpoint,omitempty"`
-	} `json:"participants"`
-	ModelFileName string `json:"modelFileName,omitempty"`
-}
-
-// 프론트엔드에서 오는 집계자 설정 구조
-type AggregatorConfigData struct {
-	Region       string `json:"region"`
-	Storage      string `json:"storage"`
-	InstanceType string `json:"instanceType"`
-}
-
-type OptimizationRequest struct {
-    FederatedLearning struct {
-        Name         string        `json:"name"`
-        Description  string        `json:"description"`
-        Algorithm    string        `json:"algorithm"`
-        Rounds       int           `json:"rounds"`
-        Participants []Participant `json:"participants"`
-    } `json:"federatedLearning"`
-    Constraints struct {
-        MaxBudget  int `json:"maxBudget"`
-        MaxLatency int `json:"maxLatency"`
-    } `json:"constraints"`
-}
-
-type Participant struct {
-    ID               string `json:"id"`
-    Name             string `json:"name"`
-    OpenstackEndpoint string `json:"openstack_endpoint"`
-}
+// 파일 분리 전 원본 파일 (혹시 모를 경우를 대비하여 파일을 삭제하는 대신 모두 주석 처리)
+
+// import (
+// 	"fmt"
+// 	"net/http"
+// 	"strings"
+
+// 	"github.com/gin-gonic/gin"
+// 	"github.com/google/uuid"
+
+// 	"github.com/Mungge/Fleecy-Cloud/models"
+// 	"github.com/Mungge/Fleecy-Cloud/repository"
+// 	"github.com/Mungge/Fleecy-Cloud/services"
+// 	"github.com/Mungge/Fleecy-Cloud/utils"
+// )
+
+// // AggregatorHandler는 Aggregator 관련 API 핸들러입니다
+// type AggregatorHandler struct {
+// 	repo   *repository.AggregatorRepository
+// 	flRepo *repository.FederatedLearningRepository
+// 	optimizationService *services.OptimizationService
+// }
+
+// // NewAggregatorHandler는 새 AggregatorHandler 인스턴스를 생성합니다
+// func NewAggregatorHandler(repo *repository.AggregatorRepository, flRepo *repository.FederatedLearningRepository) *AggregatorHandler {
+// 	return &AggregatorHandler{
+// 		repo:   repo,
+// 		flRepo: flRepo,
+// 		optimizationService: services.NewOptimizationService(),
+// 	}
+// }
+
+// // OptimizeAggregatorPlacement godoc
+// // @Summary 집계자 배치 최적화
+// // @Description NSGA-II 알고리즘을 사용하여 사용자 제약사항에 맞는 최적의 집계자 배치 위치를 찾습니다.
+// // @Tags aggregators
+// // @Accept json
+// // @Produce json
+// // @Param request body services.OptimizationRequest true "최적화 요청 정보"
+// // @Success 200 {object} map[string]interface{} "data: services.OptimizationResponse"
+// // @Failure 400 {object} map[string]string "error: 잘못된 요청"
+// // @Failure 401 {object} map[string]string "error: 인증 필요"
+// // @Failure 500 {object} map[string]string "error: 서버 오류"
+// // @Router /api/aggregator-placement-optimization [post]
+// func (h *AggregatorHandler) OptimizeAggregatorPlacement(c *gin.Context) {
+// 	// 1. 사용자 인증 확인 (선택적 - 필요에 따라)
+// 	userID, err := utils.GetUserIDFromContext(c)
+// 	if err != nil {
+// 		c.JSON(http.StatusUnauthorized, gin.H{"error": "인증이 필요합니다"})
+// 		return
+// 	}
+
+// 	// 2. 요청 데이터 파싱
+// 	var request services.OptimizationRequest
+// 	if err := c.ShouldBindJSON(&request); err != nil {
+// 		c.JSON(http.StatusBadRequest, gin.H{
+// 			"error": "잘못된 요청 형식입니다: " + err.Error(),
+// 		})
+// 		return
+// 	}
+
+// 	// 3. 요청 데이터 유효성 검증
+// 	if err := h.validateOptimizationRequest(&request); err != nil {
+// 		c.JSON(http.StatusBadRequest, gin.H{
+// 			"error": "요청 데이터 유효성 검증 실패: " + err.Error(),
+// 		})
+// 		return
+// 	}
+
+// 	// 4. Python 환경 및 스크립트 존재 여부 확인
+// 	if err := h.optimizationService.ValidatePythonEnvironment(); err != nil {
+// 		c.JSON(http.StatusInternalServerError, gin.H{
+// 			"error": "Python 환경 오류: " + err.Error(),
+// 		})
+// 		return
+// 	}
+
+// 	if err := h.optimizationService.ValidatePythonScript(); err != nil {
+// 		c.JSON(http.StatusInternalServerError, gin.H{
+// 			"error": "Python 스크립트 오류: " + err.Error(),
+// 		})
+// 		return
+// 	}
+
+// 	// 5. 최적화 실행
+// 	result, err := h.optimizationService.RunOptimization(request)
+// 	if err != nil {
+// 		c.JSON(http.StatusInternalServerError, gin.H{
+// 			"error": "집계자 배치 최적화 실행 실패: " + err.Error(),
+// 		})
+// 		return
+// 	}
+
+// 	// 6. 성공 응답 반환
+// 	c.JSON(http.StatusOK, gin.H{
+// 		"message": "집계자 배치 최적화가 성공적으로 완료되었습니다",
+// 		"data":    result,
+// 		"userID":  userID, // 디버깅용 (필요에 따라 제거)
+// 	})
+// }
+
+// // validateOptimizationRequest 요청 데이터 유효성 검증
+// func (h *AggregatorHandler) validateOptimizationRequest(request *services.OptimizationRequest) error {
+// 	// 1. 연합학습 정보 검증
+// 	if request.FederatedLearning.Name == "" {
+// 		return fmt.Errorf("연합학습 이름이 필요합니다")
+// 	}
+
+// 	if request.FederatedLearning.Algorithm == "" {
+// 		return fmt.Errorf("집계 알고리즘이 필요합니다")
+// 	}
+
+// 	if request.FederatedLearning.Rounds <= 0 {
+// 		return fmt.Errorf("라운드 수는 1 이상이어야 합니다")
+// 	}
+
+// 	// 2. 참여자 정보 검증
+// 	if len(request.FederatedLearning.Participants) == 0 {
+// 		return fmt.Errorf("최소 1명 이상의 참여자가 필요합니다")
+// 	}
+
+// 	for i, participant := range request.FederatedLearning.Participants {
+// 		if participant.ID == "" {
+// 			return fmt.Errorf("참여자 %d의 ID가 필요합니다", i+1)
+// 		}
+// 		if participant.Name == "" {
+// 			return fmt.Errorf("참여자 %d의 이름이 필요합니다", i+1)
+// 		}
+// 		if participant.OpenstackEndpoint == "" {
+// 			return fmt.Errorf("참여자 %d의 OpenStack 엔드포인트가 필요합니다", i+1)
+// 		}
+// 		// 간단한 URL 형식 검증
+// 		if !strings.HasPrefix(participant.OpenstackEndpoint, "http://") &&
+// 		   !strings.HasPrefix(participant.OpenstackEndpoint, "https://") {
+// 			return fmt.Errorf("참여자 %d의 OpenStack 엔드포인트가 올바른 URL 형식이 아닙니다", i+1)
+// 		}
+// 	}
+
+// 	// 3. 제약사항 검증
+// 	if request.AggregatorConfig.MaxBudget <= 0 {
+// 		return fmt.Errorf("최대 예산은 0보다 커야 합니다")
+// 	}
+
+// 	if request.AggregatorConfig.MaxLatency <= 0 {
+// 		return fmt.Errorf("최대 지연시간은 0보다 커야 합니다")
+// 	}
+
+// 	// 합리적인 범위 체크
+// 	if request.AggregatorConfig.MaxBudget > 10000000 { // 1천만원
+// 		return fmt.Errorf("최대 예산이 너무 큽니다 (최대: 10,000,000원)")
+// 	}
+
+// 	if request.AggregatorConfig.MaxLatency > 10000 { // 10초
+// 		return fmt.Errorf("최대 지연시간이 너무 큽니다 (최대: 10,000ms)")
+// 	}
+
+// 	return nil
+// }
+
+// // GetAggregators godoc
+// // @Summary Aggregator 목록 조회
+// // @Description 사용자의 모든 Aggregator 인스턴스를 조회합니다.
+// // @Tags aggregators
+// // @Accept json
+// // @Produce json
+// // @Success 200 {array} models.Aggregator
+// // @Failure 401 {object} map[string]string
+// // @Failure 500 {object} map[string]string
+// // @Router /api/aggregators [get]
+// func (h *AggregatorHandler) GetAggregators(c *gin.Context) {
+// 	userID, err := utils.GetUserIDFromContext(c)
+// 	if err != nil {
+// 		c.JSON(http.StatusUnauthorized, gin.H{"error": "인증이 필요합니다"})
+// 		return
+// 	}
+
+// 	aggregators, err := h.repo.GetAggregatorsByUserID(userID)
+// 	if err != nil {
+// 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Aggregator 목록 조회 실패"})
+// 		return
+// 	}
+
+// 	c.JSON(http.StatusOK, aggregators)
+// }
+
+// // GetAggregator godoc
+// // @Summary 특정 Aggregator 조회
+// // @Description ID로 특정 Aggregator를 조회합니다.
+// // @Tags aggregators
+// // @Accept json
+// // @Produce json
+// // @Param id path string true "Aggregator ID"
+// // @Success 200 {object} models.Aggregator
+// // @Failure 401 {object} map[string]string
+// // @Failure 404 {object} map[string]string
+// // @Failure 500 {object} map[string]string
+// // @Router /api/aggregators/{id} [get]
+// func (h *AggregatorHandler) GetAggregator(c *gin.Context) {
+// 	userID, err := utils.GetUserIDFromContext(c)
+// 	if err != nil {
+// 		c.JSON(http.StatusUnauthorized, gin.H{"error": "인증이 필요합니다"})
+// 		return
+// 	}
+
+// 	id := c.Param("id")
+// 	aggregator, err := h.repo.GetAggregatorByID(id)
+// 	if err != nil {
+// 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Aggregator 조회 실패"})
+// 		return
+// 	}
+
+// 	if aggregator == nil || aggregator.UserID != userID {
+// 		c.JSON(http.StatusNotFound, gin.H{"error": "Aggregator를 찾을 수 없습니다"})
+// 		return
+// 	}
+
+// 	c.JSON(http.StatusOK, aggregator)
+// }
+
+// // UpdateAggregatorStatus godoc
+// // @Summary Aggregator 상태 업데이트
+// // @Description Aggregator의 상태를 업데이트합니다.
+// // @Tags aggregators
+// // @Accept json
+// // @Produce json
+// // @Param id path string true "Aggregator ID"
+// // @Param status body UpdateStatusRequest true "상태 정보"
+// // @Success 200 {object} map[string]string
+// // @Failure 400 {object} map[string]string
+// // @Failure 401 {object} map[string]string
+// // @Failure 404 {object} map[string]string
+// // @Failure 500 {object} map[string]string
+// // @Router /api/aggregators/{id}/status [put]
+// func (h *AggregatorHandler) UpdateAggregatorStatus(c *gin.Context) {
+// 	userID, err := utils.GetUserIDFromContext(c)
+// 	if err != nil {
+// 		c.JSON(http.StatusUnauthorized, gin.H{"error": "인증이 필요합니다"})
+// 		return
+// 	}
+
+// 	id := c.Param("id")
+
+// 	// 권한 확인
+// 	aggregator, err := h.repo.GetAggregatorByID(id)
+// 	if err != nil {
+// 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Aggregator 조회 실패"})
+// 		return
+// 	}
+// 	if aggregator == nil || aggregator.UserID != userID {
+// 		c.JSON(http.StatusNotFound, gin.H{"error": "Aggregator를 찾을 수 없습니다"})
+// 		return
+// 	}
+
+// 	var request UpdateStatusRequest
+// 	if err := c.ShouldBindJSON(&request); err != nil {
+// 		c.JSON(http.StatusBadRequest, gin.H{"error": "잘못된 요청 형식입니다"})
+// 		return
+// 	}
+
+// 	if err := h.repo.UpdateAggregatorStatus(id, request.Status); err != nil {
+// 		c.JSON(http.StatusInternalServerError, gin.H{"error": "상태 업데이트 실패"})
+// 		return
+// 	}
+
+// 	c.JSON(http.StatusOK, gin.H{"message": "상태가 업데이트되었습니다"})
+// }
+
+// // UpdateAggregatorMetrics godoc
+// // @Summary Aggregator 메트릭 업데이트
+// // @Description Aggregator의 실시간 메트릭을 업데이트합니다.
+// // @Tags aggregators
+// // @Accept json
+// // @Produce json
+// // @Param id path string true "Aggregator ID"
+// // @Param metrics body UpdateMetricsRequest true "메트릭 정보"
+// // @Success 200 {object} map[string]string
+// // @Failure 400 {object} map[string]string
+// // @Failure 401 {object} map[string]string
+// // @Failure 404 {object} map[string]string
+// // @Failure 500 {object} map[string]string
+// // @Router /api/aggregators/{id}/metrics [put]
+// func (h *AggregatorHandler) UpdateAggregatorMetrics(c *gin.Context) {
+// 	userID, err := utils.GetUserIDFromContext(c)
+// 	if err != nil {
+// 		c.JSON(http.StatusUnauthorized, gin.H{"error": "인증이 필요합니다"})
+// 		return
+// 	}
+
+// 	id := c.Param("id")
+
+// 	// 권한 확인
+// 	aggregator, err := h.repo.GetAggregatorByID(id)
+// 	if err != nil {
+// 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Aggregator 조회 실패"})
+// 		return
+// 	}
+// 	if aggregator == nil || aggregator.UserID != userID {
+// 		c.JSON(http.StatusNotFound, gin.H{"error": "Aggregator를 찾을 수 없습니다"})
+// 		return
+// 	}
+
+// 	var request UpdateMetricsRequest
+// 	if err := c.ShouldBindJSON(&request); err != nil {
+// 		c.JSON(http.StatusBadRequest, gin.H{"error": "잘못된 요청 형식입니다"})
+// 		return
+// 	}
+
+// 	err = h.repo.UpdateAggregatorMetrics(id, request.CPUUsage, request.MemoryUsage, request.NetworkUsage)
+// 	if err != nil {
+// 		c.JSON(http.StatusInternalServerError, gin.H{"error": "메트릭 업데이트 실패"})
+// 		return
+// 	}
+
+// 	c.JSON(http.StatusOK, gin.H{"message": "메트릭이 업데이트되었습니다"})
+// }
+
+// // GetTrainingHistory godoc
+// // @Summary 학습 히스토리 조회
+// // @Description Aggregator의 학습 히스토리를 조회합니다.
+// // @Tags aggregators
+// // @Accept json
+// // @Produce json
+// // @Param id path string true "Aggregator ID"
+// // @Success 200 {array} models.TrainingRound
+// // @Failure 401 {object} map[string]string
+// // @Failure 404 {object} map[string]string
+// // @Failure 500 {object} map[string]string
+// // @Router /api/aggregators/{id}/training-history [get]
+// func (h *AggregatorHandler) GetTrainingHistory(c *gin.Context) {
+// 	userID, err := utils.GetUserIDFromContext(c)
+// 	if err != nil {
+// 		c.JSON(http.StatusUnauthorized, gin.H{"error": "인증이 필요합니다"})
+// 		return
+// 	}
+
+// 	id := c.Param("id")
+
+// 	// 권한 확인
+// 	aggregator, err := h.repo.GetAggregatorByID(id)
+// 	if err != nil {
+// 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Aggregator 조회 실패"})
+// 		return
+// 	}
+// 	if aggregator == nil || aggregator.UserID != userID {
+// 		c.JSON(http.StatusNotFound, gin.H{"error": "Aggregator를 찾을 수 없습니다"})
+// 		return
+// 	}
+
+// 	rounds, err := h.repo.GetTrainingRoundsByAggregatorID(id)
+// 	if err != nil {
+// 		c.JSON(http.StatusInternalServerError, gin.H{"error": "학습 히스토리 조회 실패"})
+// 		return
+// 	}
+
+// 	c.JSON(http.StatusOK, rounds)
+// }
+
+// // GetAggregatorStats godoc
+// // @Summary Aggregator 통계 조회
+// // @Description 사용자의 Aggregator 통계를 조회합니다.
+// // @Tags aggregators
+// // @Accept json
+// // @Produce json
+// // @Success 200 {object} map[string]interface{}
+// // @Failure 401 {object} map[string]string
+// // @Failure 500 {object} map[string]string
+// // @Router /api/aggregators/stats [get]
+// func (h *AggregatorHandler) GetAggregatorStats(c *gin.Context) {
+// 	userID, err := utils.GetUserIDFromContext(c)
+// 	if err != nil {
+// 		c.JSON(http.StatusUnauthorized, gin.H{"error": "인증이 필요합니다"})
+// 		return
+// 	}
+
+// 	stats, err := h.repo.GetAggregatorStats(userID)
+// 	if err != nil {
+// 		c.JSON(http.StatusInternalServerError, gin.H{"error": "통계 조회 실패"})
+// 		return
+// 	}
+
+// 	c.JSON(http.StatusOK, stats)
+// }
+
+// // DeleteAggregator godoc
+// // @Summary Aggregator 삭제
+// // @Description Aggregator를 삭제합니다.
+// // @Tags aggregators
+// // @Accept json
+// // @Produce json
+// // @Param id path string true "Aggregator ID"
+// // @Success 200 {object} map[string]string
+// // @Failure 401 {object} map[string]string
+// // @Failure 404 {object} map[string]string
+// // @Failure 500 {object} map[string]string
+// // @Router /api/aggregators/{id} [delete]
+// func (h *AggregatorHandler) DeleteAggregator(c *gin.Context) {
+// 	userID, err := utils.GetUserIDFromContext(c)
+// 	if err != nil {
+// 		c.JSON(http.StatusUnauthorized, gin.H{"error": "인증이 필요합니다"})
+// 		return
+// 	}
+
+// 	id := c.Param("id")
+
+// 	// 권한 확인
+// 	aggregator, err := h.repo.GetAggregatorByID(id)
+// 	if err != nil {
+// 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Aggregator 조회 실패"})
+// 		return
+// 	}
+// 	if aggregator == nil || aggregator.UserID != userID {
+// 		c.JSON(http.StatusNotFound, gin.H{"error": "Aggregator를 찾을 수 없습니다"})
+// 		return
+// 	}
+
+// 	if err := h.repo.DeleteAggregator(id); err != nil {
+// 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Aggregator 삭제 실패"})
+// 		return
+// 	}
+
+// 	c.JSON(http.StatusOK, gin.H{"message": "Aggregator가 삭제되었습니다"})
+// }
+
+// // CreateAggregator godoc
+// // @Summary 새 Aggregator 생성
+// // @Description 새로운 Aggregator 인스턴스를 생성하고 Terraform으로 인프라를 배포합니다.
+// // @Tags aggregators
+// // @Accept json
+// // @Produce json
+// // @Param aggregator body CreateAggregatorRequest true "Aggregator 생성 정보"
+// // @Success 201 {object} CreateAggregatorResponse
+// // @Failure 400 {object} map[string]string
+// // @Failure 401 {object} map[string]string
+// // @Failure 500 {object} map[string]string
+// // @Router /api/aggregators [post]
+// func (h *AggregatorHandler) CreateAggregator(c *gin.Context) {
+// 	userID, err := utils.GetUserIDFromContext(c)
+// 	if err != nil {
+// 		c.JSON(http.StatusUnauthorized, gin.H{"error": "인증이 필요합니다"})
+// 		return
+// 	}
+
+// 	var request CreateAggregatorRequest
+// 	if err := c.ShouldBindJSON(&request); err != nil {
+// 		c.JSON(http.StatusBadRequest, gin.H{"error": "잘못된 요청 형식입니다: " + err.Error()})
+// 		return
+// 	}
+
+// 	// Aggregator 생성
+// 	aggregator := &models.Aggregator{
+// 		ID:            uuid.New().String(),
+// 		UserID:       userID,
+// 		Name:         request.Name,
+// 		Status:       "creating",
+// 		Algorithm:    request.Algorithm,
+// 		CloudProvider: "openstack",
+// 		Region:       request.Region,
+// 		InstanceType: request.InstanceType,
+// 		StorageSpecs: request.Storage + "GB",
+// 	}
+
+// 	// DB에 저장
+// 	if err := h.repo.CreateAggregator(aggregator); err != nil {
+// 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Aggregator 생성 실패: " + err.Error()})
+// 		return
+// 	}
+
+// 	// Terraform 배포 시작 (비동기)
+// 	go func() {
+// 		if err := h.deployWithTerraform(aggregator); err != nil {
+// 			aggregator.Status = "failed"
+// 			h.repo.UpdateAggregator(aggregator)
+// 			return
+// 		}
+// 		aggregator.Status = "running"
+// 		h.repo.UpdateAggregator(aggregator)
+// 	}()
+
+// 	// 응답 반환
+// 	response := CreateAggregatorResponse{
+// 		AggregatorID:    aggregator.ID,
+// 		Status:          "creating",
+// 		TerraformStatus: "deploying",
+// 	}
+
+// 	c.JSON(http.StatusCreated, gin.H{"data": response})
+// }
+
+// // deployWithTerraform은 Terraform을 사용하여 인프라를 배포합니다
+// func (h *AggregatorHandler) deployWithTerraform(aggregator *models.Aggregator) error {
+// 	// Terraform 설정 생성
+// 	config := utils.TerraformConfig{
+// 		Region:       aggregator.Region,
+// 		InstanceType: aggregator.InstanceType,
+// 		ProjectName:  "fleecy-aggregator",
+// 		Environment:  "production",
+// 	}
+
+// 	// Terraform 작업공간 생성
+// 	workspaceDir, err := utils.CreateTerraformWorkspace(aggregator.ID, config)
+// 	if err != nil {
+// 		return err
+// 	}
+
+// 	// Terraform 배포 실행
+// 	result, err := utils.DeployWithTerraform(workspaceDir)
+// 	if err != nil {
+// 		return err
+// 	}
+
+// 	// 배포 결과를 aggregator에 저장
+// 	aggregator.InstanceID = result.InstanceID
+// 	aggregator.Status = "running"
+// 	if aggregator.Configuration == nil {
+// 		aggregator.Configuration = make(map[string]interface{})
+// 	}
+// 	aggregator.Configuration["public_ip"] = result.PublicIP
+// 	aggregator.Configuration["private_ip"] = result.PrivateIP
+// 	aggregator.Configuration["workspace_dir"] = result.WorkspaceDir
+
+// 	return nil
+// }
+
+// // Request/Response structures
+// type UpdateStatusRequest struct {
+// 	Status string `json:"status" binding:"required"`
+// }
+
+// type UpdateMetricsRequest struct {
+// 	CPUUsage     float64 `json:"cpu_usage"`
+// 	MemoryUsage  float64 `json:"memory_usage"`
+// 	NetworkUsage float64 `json:"network_usage"`
+// }
+
+// // Aggregator 생성 요청 구조
+// type CreateAggregatorRequest struct {
+// 	Name         string `json:"name" binding:"required"`
+// 	Algorithm    string `json:"algorithm" binding:"required"`
+// 	Region       string `json:"region" binding:"required"`
+// 	Storage      string `json:"storage" binding:"required"`
+// 	InstanceType string `json:"instanceType" binding:"required"`
+// }
+
+// // Aggregator 생성 응답 구조
+// type CreateAggregatorResponse struct {
+// 	AggregatorID    string `json:"aggregatorId"`
+// 	Status          string `json:"status"`
+// 	TerraformStatus string `json:"terraformStatus,omitempty"`
+// }
+
+// // 프론트엔드에서 오는 연합학습 데이터 구조 (통합 생성용)
+// type FederatedLearningData struct {
+// 	Name         string `json:"name"`
+// 	Description  string `json:"description"`
+// 	ModelType    string `json:"modelType"`
+// 	Algorithm    string `json:"algorithm"`
+// 	Rounds       int    `json:"rounds"`
+// 	Participants []struct {
+// 		ID                string `json:"id"`
+// 		Name              string `json:"name"`
+// 		Status            string `json:"status"`
+// 		OpenstackEndpoint string `json:"openstack_endpoint,omitempty"`
+// 	} `json:"participants"`
+// 	ModelFileName string `json:"modelFileName,omitempty"`
+// }
+
+// // 프론트엔드에서 오는 집계자 설정 구조
+// type AggregatorConfigData struct {
+// 	Region       string `json:"region"`
+// 	Storage      string `json:"storage"`
+// 	InstanceType string `json:"instanceType"`
+// }
+
+// type OptimizationRequest struct {
+//     FederatedLearning struct {
+//         Name         string        `json:"name"`
+//         Description  string        `json:"description"`
+//         Algorithm    string        `json:"algorithm"`
+//         Rounds       int           `json:"rounds"`
+//         Participants []Participant `json:"participants"`
+//     } `json:"federatedLearning"`
+//     Constraints struct {
+//         MaxBudget  int `json:"maxBudget"`
+//         MaxLatency int `json:"maxLatency"`
+//     } `json:"constraints"`
+// }
+
+// type Participant struct {
+//     ID               string `json:"id"`
+//     Name             string `json:"name"`
+//     OpenstackEndpoint string `json:"openstack_endpoint"`
+// }

--- a/backend/main.go
+++ b/backend/main.go
@@ -23,6 +23,9 @@ func main() {
 	// 리포지토리 초기화
 	repos := initialization.InitializeRepositories()
 
+	// Aggregator 의존성 초기화
+	aggregatorDeps := initialization.NewDependencies()
+
 	// 핸들러 초기화
 	authHandler := authHandlers.NewAuthHandler(
 		repos.UserRepo,
@@ -33,7 +36,7 @@ func main() {
 	cloudHandler := handlers.NewCloudHandler(repos.CloudRepo)
 	flHandler := handlers.NewFederatedLearningHandler(repos.FLRepo)
 	participantHandler := handlers.NewParticipantHandler(repos.ParticipantRepo)
-	aggregatorHandler := handlers.NewAggregatorHandler(repos.AggregatorRepo, repos.FLRepo)
+	aggregatorHandler := aggregatorDeps.AggregatorHandler
 
 	// Gin 라우터 설정
 	r := gin.Default()

--- a/backend/routes/aggregator_routes.go
+++ b/backend/routes/aggregator_routes.go
@@ -1,11 +1,11 @@
 package routes
 
 import (
-	"github.com/Mungge/Fleecy-Cloud/handlers"
+	"github.com/Mungge/Fleecy-Cloud/handlers/aggregator"
 	"github.com/gin-gonic/gin"
 )
 
-func SetupAggregatorRoutes(authorized *gin.RouterGroup, aggregatorHandler *handlers.AggregatorHandler) {
+func SetupAggregatorRoutes(authorized *gin.RouterGroup, aggregatorHandler *aggregator.AggregatorHandler) {
 	aggregators := authorized.Group("/aggregators")
 	{
 		// Aggregator 배치 최적화

--- a/backend/services/aggregator/errors.go
+++ b/backend/services/aggregator/errors.go
@@ -1,0 +1,16 @@
+package aggregator
+
+import "errors"
+
+// Aggregator 서비스 관련 에러들
+var (
+	ErrAggregatorNotFound     = errors.New("aggregator not found or access denied")
+	ErrInvalidUserID          = errors.New("invalid user ID")
+	ErrInvalidAggregatorID    = errors.New("invalid aggregator ID")
+	ErrAggregatorCreateFailed = errors.New("failed to create aggregator")
+	ErrAggregatorUpdateFailed = errors.New("failed to update aggregator")
+	ErrAggregatorDeleteFailed = errors.New("failed to delete aggregator")
+	ErrTerraformDeployFailed  = errors.New("terraform deployment failed")
+	ErrInvalidMetricsData     = errors.New("invalid metrics data")
+	ErrInvalidStatus          = errors.New("invalid status")
+)

--- a/backend/services/aggregator/metrices_service.go
+++ b/backend/services/aggregator/metrices_service.go
@@ -1,0 +1,50 @@
+package aggregator
+
+import (
+	"github.com/Mungge/Fleecy-Cloud/repository"
+)
+
+// AggregatorMetricsService는 Aggregator 메트릭 관련 비즈니스 로직을 처리합니다
+type AggregatorMetricsService struct {
+	repo *repository.AggregatorRepository
+}
+
+// NewAggregatorMetricsService는 새 AggregatorMetricsService 인스턴스를 생성합니다
+func NewAggregatorMetricsService(repo *repository.AggregatorRepository) *AggregatorMetricsService {
+	return &AggregatorMetricsService{
+		repo: repo,
+	}
+}
+
+// UpdateStatus는 Aggregator의 상태를 업데이트합니다
+func (s *AggregatorMetricsService) UpdateStatus(aggregatorID string, userID int64, status string) error {
+	// 권한 확인
+	aggregator, err := s.repo.GetAggregatorByID(aggregatorID)
+	if err != nil {
+		return err
+	}
+	if aggregator == nil || aggregator.UserID != userID {
+		return ErrAggregatorNotFound
+	}
+
+	return s.repo.UpdateAggregatorStatus(aggregatorID, status)
+}
+
+// UpdateMetrics는 Aggregator의 메트릭을 업데이트합니다
+func (s *AggregatorMetricsService) UpdateMetrics(aggregatorID string, userID int64, cpuUsage, memoryUsage, networkUsage float64) error {
+	// 권한 확인
+	aggregator, err := s.repo.GetAggregatorByID(aggregatorID)
+	if err != nil {
+		return err
+	}
+	if aggregator == nil || aggregator.UserID != userID {
+		return ErrAggregatorNotFound
+	}
+
+	return s.repo.UpdateAggregatorMetrics(aggregatorID, cpuUsage, memoryUsage, networkUsage)
+}
+
+// GetStats는 사용자의 Aggregator 통계를 조회합니다
+func (s *AggregatorMetricsService) GetStats(userID int64) (map[string]interface{}, error) {
+	return s.repo.GetAggregatorStats(userID)
+}

--- a/backend/services/aggregator/optimization_adapter.go
+++ b/backend/services/aggregator/optimization_adapter.go
@@ -1,0 +1,74 @@
+package aggregator
+
+import (
+	"github.com/Mungge/Fleecy-Cloud/services"
+)
+
+// OptimizationServiceAdapter는 기존 services.OptimizationService를 새로운 인터페이스에 맞게 어댑트합니다
+type OptimizationServiceAdapter struct {
+	service *services.OptimizationService
+}
+
+// NewOptimizationServiceAdapter는 새로운 어댑터 인스턴스를 생성합니다
+func NewOptimizationServiceAdapter(service *services.OptimizationService) OptimizationService {
+	return &OptimizationServiceAdapter{
+		service: service,
+	}
+}
+
+// ValidatePythonEnvironment은 Python 환경을 검증합니다
+func (a *OptimizationServiceAdapter) ValidatePythonEnvironment() error {
+	return a.service.ValidatePythonEnvironment()
+}
+
+// ValidatePythonScript는 Python 스크립트를 검증합니다
+func (a *OptimizationServiceAdapter) ValidatePythonScript() error {
+	return a.service.ValidatePythonScript()
+}
+
+// RunOptimization은 최적화를 실행합니다
+func (a *OptimizationServiceAdapter) RunOptimization(request OptimizationRequest) (interface{}, error) {
+	// 타입 변환: aggregator.OptimizationRequest -> services.OptimizationRequest
+	serviceRequest := services.OptimizationRequest{
+		FederatedLearning: struct {
+			Name          string                `json:"name"`
+			Description   string                `json:"description"`
+			ModelType     string                `json:"modelType"`
+			Algorithm     string                `json:"algorithm"`
+			Rounds        int                   `json:"rounds"`
+			Participants  []services.Participant `json:"participants"`
+			ModelFileName *string               `json:"modelFileName,omitempty"`
+		}{
+			Name:          request.FederatedLearning.Name,
+			Description:   request.FederatedLearning.Description,
+			ModelType:     "default", // 기본값 설정
+			Algorithm:     request.FederatedLearning.Algorithm,
+			Rounds:        request.FederatedLearning.Rounds,
+			ModelFileName: nil, // 기본값 nil
+		},
+		AggregatorConfig: struct {
+			MaxBudget  int `json:"maxBudget"`
+			MaxLatency int `json:"maxLatency"`
+		}{
+			MaxBudget:  request.AggregatorConfig.MaxBudget,
+			MaxLatency: request.AggregatorConfig.MaxLatency,
+		},
+	}
+
+	// Participants 변환
+	for _, p := range request.FederatedLearning.Participants {
+		participant := services.Participant{
+			ID:                p.ID,
+			Name:              p.Name,
+			Status:            "active", // 기본값 설정
+			Region:            "default", // 기본값 설정 (필요시 요청에서 추가)
+			OpenstackEndpoint: p.OpenstackEndpoint,
+		}
+		serviceRequest.FederatedLearning.Participants = append(
+			serviceRequest.FederatedLearning.Participants,
+			participant,
+		)
+	}
+
+	return a.service.RunOptimization(serviceRequest)
+}

--- a/backend/services/aggregator/service.go
+++ b/backend/services/aggregator/service.go
@@ -1,0 +1,180 @@
+package aggregator
+
+import (
+	"github.com/google/uuid"
+
+	"github.com/Mungge/Fleecy-Cloud/models"
+	"github.com/Mungge/Fleecy-Cloud/repository"
+	"github.com/Mungge/Fleecy-Cloud/utils"
+)
+
+// AggregatorService는 Aggregator 관련 비즈니스 로직을 처리합니다
+type AggregatorService struct {
+	repo   *repository.AggregatorRepository
+	flRepo *repository.FederatedLearningRepository
+}
+
+// NewAggregatorService는 새 AggregatorService 인스턴스를 생성합니다
+func NewAggregatorService(repo *repository.AggregatorRepository, flRepo *repository.FederatedLearningRepository) *AggregatorService {
+	return &AggregatorService{
+		repo:   repo,
+		flRepo: flRepo,
+	}
+}
+
+// CreateAggregatorInput Aggregator 생성 입력
+type CreateAggregatorInput struct {
+	Name         string
+	Algorithm    string
+	Region       string
+	Storage      string
+	InstanceType string
+	UserID       int64
+}
+
+// CreateAggregatorResult Aggregator 생성 결과
+type CreateAggregatorResult struct {
+	AggregatorID    string
+	Status          string
+	TerraformStatus string
+}
+
+// OptimizationRequest 최적화 요청 (기존 services.OptimizationRequest 대체)
+type OptimizationRequest struct {
+	FederatedLearning struct {
+		Name         string        `json:"name"`
+		Description  string        `json:"description"`
+		Algorithm    string        `json:"algorithm"`
+		Rounds       int           `json:"rounds"`
+		Participants []Participant `json:"participants"`
+	} `json:"federatedLearning"`
+	AggregatorConfig struct {
+		MaxBudget  int `json:"maxBudget"`
+		MaxLatency int `json:"maxLatency"`
+	} `json:"aggregatorConfig"`
+}
+
+// Participant 참여자 정보
+type Participant struct {
+	ID                string `json:"id"`
+	Name              string `json:"name"`
+	OpenstackEndpoint string `json:"openstack_endpoint"`
+}
+
+// OptimizationService 인터페이스 (기존 services.OptimizationService 대체)
+type OptimizationService interface {
+	ValidatePythonEnvironment() error
+	ValidatePythonScript() error
+	RunOptimization(request OptimizationRequest) (interface{}, error)
+}
+
+// CreateAggregator는 새로운 Aggregator를 생성합니다
+func (s *AggregatorService) CreateAggregator(input CreateAggregatorInput) (*CreateAggregatorResult, error) {
+	// Aggregator 생성
+	aggregator := &models.Aggregator{
+		ID:            uuid.New().String(),
+		UserID:        input.UserID,
+		Name:          input.Name,
+		Status:        "creating",
+		Algorithm:     input.Algorithm,
+		CloudProvider: "openstack",
+		Region:        input.Region,
+		InstanceType:  input.InstanceType,
+		StorageSpecs:  input.Storage + "GB",
+	}
+
+	// DB에 저장
+	if err := s.repo.CreateAggregator(aggregator); err != nil {
+		return nil, err
+	}
+
+	// Terraform 배포 시작 (비동기)
+	go func() {
+		if err := s.deployWithTerraform(aggregator); err != nil {
+			aggregator.Status = "failed"
+			s.repo.UpdateAggregator(aggregator)
+			return
+		}
+		aggregator.Status = "running"
+		s.repo.UpdateAggregator(aggregator)
+	}()
+
+	// 결과 반환
+	result := &CreateAggregatorResult{
+		AggregatorID:    aggregator.ID,
+		Status:          "creating",
+		TerraformStatus: "deploying",
+	}
+
+	return result, nil
+}
+
+// GetAggregatorByID는 ID로 Aggregator를 조회하고 권한을 확인합니다
+func (s *AggregatorService) GetAggregatorByID(id string, userID int64) (*models.Aggregator, error) {
+	aggregator, err := s.repo.GetAggregatorByID(id)
+	if err != nil {
+		return nil, err
+	}
+
+	if aggregator == nil || aggregator.UserID != userID {
+		return nil, nil // 권한 없음 또는 존재하지 않음
+	}
+
+	return aggregator, nil
+}
+
+// DeleteAggregator는 Aggregator를 삭제합니다
+func (s *AggregatorService) DeleteAggregator(id string, userID int64) error {
+	// 권한 확인
+	aggregator, err := s.GetAggregatorByID(id, userID)
+	if err != nil {
+		return err
+	}
+	if aggregator == nil {
+		return ErrAggregatorNotFound
+	}
+
+	return s.repo.DeleteAggregator(id)
+}
+
+// deployWithTerraform은 Terraform을 사용하여 인프라를 배포합니다
+func (s *AggregatorService) deployWithTerraform(aggregator *models.Aggregator) error {
+	// Terraform 설정 생성
+	config := utils.TerraformConfig{
+		Region:       aggregator.Region,
+		InstanceType: aggregator.InstanceType,
+		ProjectName:  "fleecy-aggregator",
+		Environment:  "production",
+	}
+	
+	// Terraform 작업공간 생성
+	workspaceDir, err := utils.CreateTerraformWorkspace(aggregator.ID, config)
+	if err != nil {
+		return err
+	}
+	
+	// Terraform 배포 실행
+	result, err := utils.DeployWithTerraform(workspaceDir)
+	if err != nil {
+		return err
+	}
+	
+	// 배포 결과를 aggregator에 저장
+	aggregator.InstanceID = result.InstanceID
+	aggregator.Status = "running"
+	if aggregator.Configuration == nil {
+		aggregator.Configuration = make(map[string]interface{})
+	}
+	aggregator.Configuration["public_ip"] = result.PublicIP
+	aggregator.Configuration["private_ip"] = result.PrivateIP
+	aggregator.Configuration["workspace_dir"] = result.WorkspaceDir
+	
+	return nil
+}
+
+//GetAggregatorsByUser는 사용자의 모든 Aggregator를 조회합니다
+func (s *AggregatorService) GetAggregatorsByUser(userID int64) ([]*models.Aggregator, error) {
+	return s.repo.GetAggregatorsByUserID(userID)
+}
+
+// GetAggregator

--- a/backend/services/aggregator/training_service.go
+++ b/backend/services/aggregator/training_service.go
@@ -1,0 +1,32 @@
+package aggregator
+
+import (
+	"github.com/Mungge/Fleecy-Cloud/models"
+	"github.com/Mungge/Fleecy-Cloud/repository"
+)
+
+// AggregatorTrainingService는 Aggregator 학습 관련 비즈니스 로직을 처리합니다
+type AggregatorTrainingService struct {
+	repo *repository.AggregatorRepository
+}
+
+// NewAggregatorTrainingService는 새 AggregatorTrainingService 인스턴스를 생성합니다
+func NewAggregatorTrainingService(repo *repository.AggregatorRepository) *AggregatorTrainingService {
+	return &AggregatorTrainingService{
+		repo: repo,
+	}
+}
+
+// GetTrainingHistory는 Aggregator의 학습 히스토리를 조회합니다
+func (s *AggregatorTrainingService) GetTrainingHistory(aggregatorID string, userID int64) ([]*models.TrainingRound, error) {
+	// 권한 확인
+	aggregator, err := s.repo.GetAggregatorByID(aggregatorID)
+	if err != nil {
+		return nil, err
+	}
+	if aggregator == nil || aggregator.UserID != userID {
+		return nil, ErrAggregatorNotFound
+	}
+
+	return s.repo.GetTrainingRoundsByAggregatorID(aggregatorID)
+}

--- a/backend/validators/aggregator/validator.go
+++ b/backend/validators/aggregator/validator.go
@@ -1,0 +1,161 @@
+package aggregatorvalidator
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Mungge/Fleecy-Cloud/services/aggregator"
+)
+
+// ValidateCreateAggregatorRequest는 Aggregator 생성 요청을 검증합니다
+func ValidateCreateAggregatorRequest(name, algorithm, region, storage, instanceType string) error {
+	if strings.TrimSpace(name) == "" {
+		return fmt.Errorf("aggregator 이름이 필요합니다")
+	}
+
+	if len(name) > 100 {
+		return fmt.Errorf("aggregator 이름은 100자를 초과할 수 없습니다")
+	}
+
+	if strings.TrimSpace(algorithm) == "" {
+		return fmt.Errorf("집계 알고리즘이 필요합니다")
+	}
+
+	validAlgorithms := []string{"fedavg", "fedprox", "fedopt", "scaffold"}
+	if !contains(validAlgorithms, strings.ToLower(algorithm)) {
+		return fmt.Errorf("지원하지 않는 알고리즘입니다: %s", algorithm)
+	}
+
+	if strings.TrimSpace(region) == "" {
+		return fmt.Errorf("지역 정보가 필요합니다")
+	}
+
+	if strings.TrimSpace(storage) == "" {
+		return fmt.Errorf("스토리지 정보가 필요합니다")
+	}
+
+	if strings.TrimSpace(instanceType) == "" {
+		return fmt.Errorf("인스턴스 타입이 필요합니다")
+	}
+
+	return nil
+}
+
+// ValidateUpdateStatusRequest는 상태 업데이트 요청을 검증합니다
+func ValidateUpdateStatusRequest(status string) error {
+	if strings.TrimSpace(status) == "" {
+		return fmt.Errorf("상태 정보가 필요합니다")
+	}
+
+	validStatuses := []string{"creating", "running", "stopped", "failed", "terminated"}
+	if !contains(validStatuses, strings.ToLower(status)) {
+		return fmt.Errorf("유효하지 않은 상태입니다: %s", status)
+	}
+
+	return nil
+}
+
+// ValidateUpdateMetricsRequest는 메트릭 업데이트 요청을 검증합니다
+func ValidateUpdateMetricsRequest(cpuUsage, memoryUsage, networkUsage float64) error {
+	if cpuUsage < 0 || cpuUsage > 100 {
+		return fmt.Errorf("CPU 사용률은 0-100 사이여야 합니다: %.2f", cpuUsage)
+	}
+
+	if memoryUsage < 0 || memoryUsage > 100 {
+		return fmt.Errorf("메모리 사용률은 0-100 사이여야 합니다: %.2f", memoryUsage)
+	}
+
+	if networkUsage < 0 {
+		return fmt.Errorf("네트워크 사용량은 0 이상이어야 합니다: %.2f", networkUsage)
+	}
+
+	return nil
+}
+
+// ValidateOptimizationRequest는 최적화 요청을 검증합니다
+func ValidateOptimizationRequest(request *aggregator.OptimizationRequest) error {
+	// 1. 연합학습 정보 검증
+	if strings.TrimSpace(request.FederatedLearning.Name) == "" {
+		return fmt.Errorf("연합학습 이름이 필요합니다")
+	}
+
+	if strings.TrimSpace(request.FederatedLearning.Algorithm) == "" {
+		return fmt.Errorf("집계 알고리즘이 필요합니다")
+	}
+
+	if request.FederatedLearning.Rounds <= 0 {
+		return fmt.Errorf("라운드 수는 1 이상이어야 합니다")
+	}
+
+	if request.FederatedLearning.Rounds > 1000 {
+		return fmt.Errorf("라운드 수가 너무 큽니다 (최대: 1000)")
+	}
+
+	// 2. 참여자 정보 검증
+	if len(request.FederatedLearning.Participants) == 0 {
+		return fmt.Errorf("최소 1명 이상의 참여자가 필요합니다")
+	}
+
+	if len(request.FederatedLearning.Participants) > 100 {
+		return fmt.Errorf("참여자 수가 너무 많습니다 (최대: 100명)")
+	}
+
+	for i, participant := range request.FederatedLearning.Participants {
+		if err := validateParticipant(participant, i+1); err != nil {
+			return err
+		}
+	}
+
+	// 3. 제약사항 검증
+	if request.AggregatorConfig.MaxBudget <= 0 {
+		return fmt.Errorf("최대 예산은 0보다 커야 합니다")
+	}
+
+	if request.AggregatorConfig.MaxLatency <= 0 {
+		return fmt.Errorf("최대 지연시간은 0보다 커야 합니다")
+	}
+
+	// 합리적인 범위 체크
+	if request.AggregatorConfig.MaxBudget > 10000000 { // 1천만원
+		return fmt.Errorf("최대 예산이 너무 큽니다 (최대: 10,000,000원)")
+	}
+
+	if request.AggregatorConfig.MaxLatency > 10000 { // 10초
+		return fmt.Errorf("최대 지연시간이 너무 큽니다 (최대: 10,000ms)")
+	}
+
+	return nil
+}
+
+// validateParticipant는 참여자 정보를 검증합니다
+func validateParticipant(participant aggregator.Participant, index int) error {
+	if strings.TrimSpace(participant.ID) == "" {
+		return fmt.Errorf("참여자 %d의 ID가 필요합니다", index)
+	}
+
+	if strings.TrimSpace(participant.Name) == "" {
+		return fmt.Errorf("참여자 %d의 이름이 필요합니다", index)
+	}
+
+	if strings.TrimSpace(participant.OpenstackEndpoint) == "" {
+		return fmt.Errorf("참여자 %d의 OpenStack 엔드포인트가 필요합니다", index)
+	}
+
+	// 간단한 URL 형식 검증
+	endpoint := strings.TrimSpace(participant.OpenstackEndpoint)
+	if !strings.HasPrefix(endpoint, "http://") && !strings.HasPrefix(endpoint, "https://") {
+		return fmt.Errorf("참여자 %d의 OpenStack 엔드포인트가 올바른 URL 형식이 아닙니다", index)
+	}
+
+	return nil
+}
+
+// contains는 슬라이스에 특정 항목이 포함되어 있는지 확인합니다
+func contains(slice []string, item string) bool {
+	for _, s := range slice {
+		if s == item {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
기존의 `aggregator_handler.go`가 너무 길어서 아래와 같이 개선했습니다.
향후 다른 handler 코드의 구조를 개선하시고 싶으시다면 이 구조를 참고하셔도 좋을 듯 합니다.

```
backend/
├── handlers/
│   └── aggregator/
│       ├── handler.go                  # 메인 핸들러 (기존 AggregatorHandler)
│       ├── metrics.go                  # 메트릭 관련 메서드
│       ├── training.go                 # 학습 관련 메서드
│       ├── optimization.go             # 최적화 관련 메서드
│       └── types.go                    # Request/Response 타입 정의
├── services/
│   └── aggregator/
│       ├── service.go                  # 메인 비즈니스 로직
│       ├── metrics_service.go          # 메트릭 비즈니스 로직
│       ├── training_service.go         # 학습 비즈니스 로직
│       └── errors.go                   # 에러 정의
├── validators/
│   └── aggregator/
│       └── validator.go                # 검증 로직
├── routes/
│   └── aggregator.go                   # 기존 라우팅 유지
├── initialization/
│   └── dependencies.go                 # 의존성 주입
└── main.go
```