### PR TITLE
🐛 Fix participant region display in optimize step.

### DIFF
--- a/backend/services/aggregator/optimization_adapter.go
+++ b/backend/services/aggregator/optimization_adapter.go
@@ -61,7 +61,7 @@ func (a *OptimizationServiceAdapter) RunOptimization(request OptimizationRequest
 			ID:                p.ID,
 			Name:              p.Name,
 			Status:            "active", // 기본값 설정
-			Region:            "default", // 기본값 설정 (필요시 요청에서 추가)
+			Region:            p.Region, // 실제 Region 값 사용
 			OpenstackEndpoint: p.OpenstackEndpoint,
 		}
 		serviceRequest.FederatedLearning.Participants = append(

--- a/backend/services/aggregator/service.go
+++ b/backend/services/aggregator/service.go
@@ -58,6 +58,7 @@ type OptimizationRequest struct {
 type Participant struct {
 	ID                string `json:"id"`
 	Name              string `json:"name"`
+	Region            string `json:"region,omitempty"`
 	OpenstackEndpoint string `json:"openstack_endpoint"`
 }
 


### PR DESCRIPTION
## 수정 사항

집계자 최적화 과정에서 연합학습 참여자의 region이 default로 보이는 문제 수정.

- aggregator.Participant에 Region 필드 추가
- 하드코딩된 "default" 대신 실제 지역 값(p.Region) 사용
