### PR TITLE
🚑️ Update Prometheus datasource in VM monitoring.

### DIFF
--- a/frontend/src/components/dashboard/participants/dialogs/VMMonitoringDialog.tsx
+++ b/frontend/src/components/dashboard/participants/dialogs/VMMonitoringDialog.tsx
@@ -45,7 +45,7 @@ export function VMMonitoringDialog({
 										<iframe
 											src={`${
 												selectedParticipant.openstack_endpoint
-											}:3000/d-solo/rYdddlPWk/node-exporter-full?orgId=1&from=1754794423153&to=1754880823153&timezone=browser&var-DS_PROMETHEUS=feudbfom5j5kwc&var-job=openstack-vm&var-nodename=${
+											}:3000/d-solo/rYdddlPWk/node-exporter-full?orgId=1&timezone=browser&var-DS_PROMETHEUS=prometheus-openstack&var-job=openstack-vm&var-nodename=${
 												selectedVM.name
 											}&var-node=${getVMIPAddress()}:9100&var-diskdevices=%5Ba-z%5D%2B%7Cnvme%5B0-9%5D%2Bn%5B0-9%5D%2B%7Cmmcblk%5B0-9%5D%2B&refresh=1m&theme=light&panelId=14&__feature.dashboardSceneSolo=true`}
 											width="70%"
@@ -58,7 +58,7 @@ export function VMMonitoringDialog({
 										<iframe
 											src={`${
 												selectedParticipant.openstack_endpoint
-											}:3000/d-solo/rYdddlPWk/node-exporter-full?orgId=1&from=1754794543348&to=1754880943348&timezone=browser&var-DS_PROMETHEUS=feudbfom5j5kwc&var-job=openstack-vm&var-nodename=${
+											}:3000/d-solo/rYdddlPWk/node-exporter-full?orgId=1&timezone=browser&var-DS_PROMETHEUS=prometheus-openstack&var-job=openstack-vm&var-nodename=${
 												selectedVM.name
 											}&var-node=${getVMIPAddress()}:9100&var-diskdevices=%5Ba-z%5D%2B%7Cnvme%5B0-9%5D%2Bn%5B0-9%5D%2B%7Cmmcblk%5B0-9%5D%2B&refresh=1m&theme=light&panelId=75&__feature.dashboardSceneSolo=true`}
 											width="70%"
@@ -73,7 +73,7 @@ export function VMMonitoringDialog({
 									<iframe
 										src={`${
 											selectedParticipant.openstack_endpoint
-										}:3000/d-solo/rYdddlPWk/node-exporter-full?orgId=1&from=1754798369210&to=1754884769210&timezone=browser&var-DS_PROMETHEUS=feudbfom5j5kwc&var-job=openstack-vm&var-nodename=${
+										}:3000/d-solo/rYdddlPWk/node-exporter-full?orgId=1&timezone=browser&var-DS_PROMETHEUS=prometheus-openstack&var-job=openstack-vm&var-nodename=${
 											selectedVM.name
 										}&var-node=${getVMIPAddress()}:9100&var-diskdevices=%5Ba-z%5D%2B%7Cnvme%5B0-9%5D%2Bn%5B0-9%5D%2B%7Cmmcblk%5B0-9%5D%2B&refresh=1m&theme=light&panelId=20&__feature.dashboardSceneSolo=true`}
 										width="90%"
@@ -87,7 +87,7 @@ export function VMMonitoringDialog({
 									<iframe
 										src={`${
 											selectedParticipant.openstack_endpoint
-										}:3000/d-solo/rYdddlPWk/node-exporter-full?orgId=1&from=1754798546254&to=1754884946254&timezone=browser&var-DS_PROMETHEUS=feudbfom5j5kwc&var-job=openstack-vm&var-nodename=${
+										}:3000/d-solo/rYdddlPWk/node-exporter-full?orgId=1&timezone=browser&var-DS_PROMETHEUS=prometheus-openstack&var-job=openstack-vm&var-nodename=${
 											selectedVM.name
 										}&var-node=${getVMIPAddress()}:9100&var-diskdevices=%5Ba-z%5D%2B%7Cnvme%5B0-9%5D%2Bn%5B0-9%5D%2B%7Cmmcblk%5B0-9%5D%2B&refresh=1m&theme=light&panelId=16&__feature.dashboardSceneSolo=true`}
 										width="90%"
@@ -100,7 +100,7 @@ export function VMMonitoringDialog({
 									<iframe
 										src={`${
 											selectedParticipant.openstack_endpoint
-										}:3000/d-solo/rYdddlPWk/node-exporter-full?orgId=1&from=1754799948036&to=1754886348036&timezone=browser&var-DS_PROMETHEUS=feudbfom5j5kwc&var-job=openstack-vm&var-nodename=${
+										}:3000/d-solo/rYdddlPWk/node-exporter-full?orgId=1&timezone=browser&var-DS_PROMETHEUS=prometheus-openstack&var-job=openstack-vm&var-nodename=${
 											selectedVM.name
 										}&var-node=${getVMIPAddress()}:9100&var-diskdevices=%5Ba-z%5D%2B%7Cnvme%5B0-9%5D%2Bn%5B0-9%5D%2B%7Cmmcblk%5B0-9%5D%2B&refresh=1m&theme=light&panelId=154&__feature.dashboardSceneSolo=true`}
 										width="90%"
@@ -116,7 +116,7 @@ export function VMMonitoringDialog({
 									<iframe
 										src={`${
 											selectedParticipant.openstack_endpoint
-										}:3000/d-solo/rYdddlPWk/node-exporter-full?orgId=1&from=1754794603353&to=1754881003353&timezone=browser&var-DS_PROMETHEUS=feudbfom5j5kwc&var-job=openstack-vm&var-nodename=${
+										}:3000/d-solo/rYdddlPWk/node-exporter-full?orgId=1&timezone=browser&var-DS_PROMETHEUS=prometheus-openstack&var-job=openstack-vm&var-nodename=${
 											selectedVM.name
 										}&var-node=${getVMIPAddress()}:9100&var-diskdevices=%5Ba-z%5D%2B%7Cnvme%5B0-9%5D%2Bn%5B0-9%5D%2B%7Cmmcblk%5B0-9%5D%2B&refresh=1m&theme=light&panelId=77&__feature.dashboardSceneSolo=true`}
 										width="100%"
@@ -129,7 +129,7 @@ export function VMMonitoringDialog({
 									<iframe
 										src={`${
 											selectedParticipant.openstack_endpoint
-										}:3000/d-solo/rYdddlPWk/node-exporter-full?orgId=1&from=1754794603353&to=1754881003353&timezone=browser&var-DS_PROMETHEUS=feudbfom5j5kwc&var-job=openstack-vm&var-nodename=${
+										}:3000/d-solo/rYdddlPWk/node-exporter-full?orgId=1&timezone=browser&var-DS_PROMETHEUS=prometheus-openstack&var-job=openstack-vm&var-nodename=${
 											selectedVM.name
 										}&var-node=${getVMIPAddress()}:9100&var-diskdevices=%5Ba-z%5D%2B%7Cnvme%5B0-9%5D%2Bn%5B0-9%5D%2B%7Cmmcblk%5B0-9%5D%2B&refresh=1m&theme=light&panelId=78&__feature.dashboardSceneSolo=true`}
 										width="100%"
@@ -145,7 +145,7 @@ export function VMMonitoringDialog({
 									<iframe
 										src={`${
 											selectedParticipant.openstack_endpoint
-										}:3000/d-solo/rYdddlPWk/node-exporter-full?orgId=1&from=1754799055654&to=1754885455654&timezone=browser&var-DS_PROMETHEUS=feudbfom5j5kwc&var-job=openstack-vm&var-nodename=${
+										}:3000/d-solo/rYdddlPWk/node-exporter-full?orgId=1&timezone=browser&var-DS_PROMETHEUS=prometheus-openstack&var-job=openstack-vm&var-nodename=${
 											selectedVM.name
 										}&var-node=${getVMIPAddress()}:9100&var-diskdevices=%5Ba-z%5D%2B%7Cnvme%5B0-9%5D%2Bn%5B0-9%5D%2B%7Cmmcblk%5B0-9%5D%2B&refresh=1m&theme=light&panelId=152&__feature.dashboardSceneSolo=true`}
 										width="100%"
@@ -158,7 +158,7 @@ export function VMMonitoringDialog({
 									<iframe
 										src={`${
 											selectedParticipant.openstack_endpoint
-										}:3000/d-solo/rYdddlPWk/node-exporter-full?orgId=1&from=1754799115711&to=1754885515711&timezone=browser&var-DS_PROMETHEUS=feudbfom5j5kwc&var-job=openstack-vm&var-nodename=${
+										}:3000/d-solo/rYdddlPWk/node-exporter-full?orgId=1&timezone=browser&var-DS_PROMETHEUS=prometheus-openstack&var-job=openstack-vm&var-nodename=${
 											selectedVM.name
 										}&var-node=${getVMIPAddress()}:9100&var-diskdevices=%5Ba-z%5D%2B%7Cnvme%5B0-9%5D%2Bn%5B0-9%5D%2B%7Cmmcblk%5B0-9%5D%2B&refresh=1m&theme=light&panelId=74&__feature.dashboardSceneSolo=true`}
 										width="100%"

--- a/participant-setting/README.md
+++ b/participant-setting/README.md
@@ -71,7 +71,7 @@ OpenStack을 설치한 VM에서 아래 스크립트를 실행하면 Prometheus �
 웹 임베딩 허용을 위해 `grafana.ini` 파일을 수정합니다.
 
 ```bash
-vim ~/etc/grafana/grafana.ini
+vim /etc/grafana/grafana.ini
 ```
 
 다음 설정을 파일에 추가하거나 수정하세요:
@@ -87,6 +87,12 @@ org_role = Viewer
 [security]
 allow_embedding = true
 ```
+
+### 3-3. Datasource 파일 생성
+
+prometheus datasource를 추가하기 위해, /etc/grafana/provisioning/datasources에 prometheus.yml파일 생성.
+
+> > 💡 **TIP:** 현재 디렉토리의 prometheus.yml를 복사하세요.
 
 설정 변경 후 Grafana 서비스를 재시작
 

--- a/participant-setting/prometheus.yml
+++ b/participant-setting/prometheus.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://localhost:9090
+    isDefault: true
+    editable: false
+    uid: prometheus-openstack


### PR DESCRIPTION
## 기존 문제 

기존에는 Grafana dashboard 임베딩 시, 여러 연합학습 참여자마다 임베딩되는 링크가 상이하여, 통합되지 않은 구조였습니다. 따라서 단일 연합학습 참여자만 모니터링이 가능하고, 다른 참여자는 모니터링이 불가능하다는 문제가 존재하였습니다.

## 해결 방안

etc/grafana/provisioning/datasources/prometheus.yml을 생성하여 datasource의 uid를 고정한다.(예시: participant-setting/prometheus.yml)

## 결과

아래는 두 개의 연합학습 참여자 각각에서 VM 모니터링 페이지를 들어간 것이며, 모든 연합학습 참여자의 vm 모니터링이 가능하다는 것을 확인할 수 있습니다. 
<img width="1818" height="888" alt="image" src="https://github.com/user-attachments/assets/975c3601-107d-4785-b437-c726412a9851" />
<img width="1818" height="888" alt="image" src="https://github.com/user-attachments/assets/d6f7c152-20ba-48d3-9315-ac66be333e17" />
