### PR TITLE
✨ Add model size calculation from definition file

### DIFF
--- a/frontend/src/components/dashboard/aggregator/aggregator-create-content.tsx
+++ b/frontend/src/components/dashboard/aggregator/aggregator-create-content.tsx
@@ -84,7 +84,7 @@ const AggregatorCreateContent = () => {
 			handleAggregatorOptimization(
 				federatedLearningData, 
 				aggregatorOptimizeConfig,
-				modelFileSize > 0 ? modelFileSize : 500);
+				);
 		}
 	};
 

--- a/frontend/src/components/dashboard/aggregator/components/AggregatorSettings.tsx
+++ b/frontend/src/components/dashboard/aggregator/components/AggregatorSettings.tsx
@@ -1,11 +1,11 @@
-// components/AggregatorSettings.tsx
-import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Label } from "@/components/ui/label";
+// components/AggregatorSettings.tsx (업데이트된 부분)
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../../../../components/ui/card";
+import { Button } from "../../../../components/ui/button";
+import { Input } from "../../../../components/ui/input";
+import { Label } from "../../../../components/ui/label";
 import { Slider } from "@/components/ui/slider";
-import { Check } from "lucide-react";
 import { AggregatorOptimizeConfig, CreationStatus } from "../aggregator.types";
-import { MemoryRequirementInfo } from "../components/MemoryRequirementInfo";
+import { MemoryRequirementInfo } from "./MemoryRequirementInfo";
 
 interface AggregatorSettingsProps {
   config: AggregatorOptimizeConfig;
@@ -13,8 +13,7 @@ interface AggregatorSettingsProps {
   onOptimize: () => void;
   isLoading: boolean;
   creationStatus: CreationStatus | null;
-  modelFileSize?: number; // 추가
-  participantCount?: number; // 추가
+  participantCount: number;
 }
 
 export const AggregatorSettings = ({
@@ -23,26 +22,24 @@ export const AggregatorSettings = ({
   onOptimize,
   isLoading,
   creationStatus,
-  modelFileSize,
-  participantCount
+  participantCount,
 }: AggregatorSettingsProps) => {
+  const canOptimize = !isLoading && (!creationStatus || creationStatus.step === "error");
+
   return (
     <Card>
       <CardHeader>
-        <CardTitle>연합학습 집계자 설정</CardTitle>
+        <CardTitle>집계자 설정</CardTitle>
         <CardDescription>
-          연합학습을 위한 집계자의 리소스를 설정하세요.
+          집계자 배치 최적화를 위한 제약 조건을 설정하세요.
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
-        {/* 메모리 요구사항 정보 표시 */}
-        {modelFileSize && participantCount && (
-          <MemoryRequirementInfo 
-            modelFileSize={modelFileSize}
-            participantCount={participantCount}
-            safetyFactor={1.5}
-          />
-        )}
+        {/* 메모리 요구사항 정보 */}
+        <MemoryRequirementInfo 
+          participantCount={participantCount}
+          safetyFactor={1.5}
+        />
 
         {/* 제약조건 설정 */}
         <div className="space-y-2">
@@ -102,38 +99,23 @@ export const AggregatorSettings = ({
           </div>
         </div>
 
-        <div className="pt-4">
+        <Button
+          onClick={onOptimize}
+          disabled={!canOptimize}
+          className="w-full"
+        >
+          {isLoading ? "최적화 중..." : "집계자 배치 최적화"}
+        </Button>
+
+        {creationStatus?.step === "selecting" && (
           <Button
             onClick={onOptimize}
-            disabled={isLoading || creationStatus?.step === "completed"}
+            variant="outline"
             className="w-full"
-            variant={
-              creationStatus?.step === "completed" ? "secondary" : "default"
-            }
           >
-            {isLoading ? (
-              <>
-                <div className="animate-spin rounded-full h-4 w-4 border-t-2 border-b-2 border-white mr-2"></div>
-                {creationStatus?.message || "생성 중..."}
-              </>
-            ) : creationStatus?.step === "completed" ? (
-              <>
-                <Check className="mr-2 h-4 w-4" />
-                생성 완료
-              </>
-            ) : creationStatus?.step === "error" ? (
-              "다시 시도"
-            ) : (
-              "집계자 배치 최적화 실행"
-            )}
+            다시 최적화하기
           </Button>
-
-          {creationStatus?.step === "completed" && (
-            <p className="text-sm text-green-600 text-center mt-2">
-              잠시 후 연합학습 페이지로 이동합니다...
-            </p>
-          )}
-        </div>
+        )}
       </CardContent>
     </Card>
   );

--- a/frontend/src/components/dashboard/aggregator/components/FederatedLearningInfo.tsx
+++ b/frontend/src/components/dashboard/aggregator/components/FederatedLearningInfo.tsx
@@ -61,14 +61,6 @@ export const FederatedLearningInfo = ({ data }: FederatedLearningInfoProps) => {
             </div>
           </div>
         )}
-        <div className="grid grid-cols-3 gap-2">
-          <div className="text-sm font-medium">모델 파일 크기:</div>
-          <div className="text-sm col-span-2">
-            {data.modelFileSize
-              ? `${(data.modelFileSize / (1024 * 1024)).toFixed(2)} MB`
-              : "정보 없음"}
-          </div>
-        </div>
 
         {/* 참여자 목록 */}
         <div className="space-y-2">

--- a/frontend/src/components/dashboard/aggregator/components/MemoryRequirementInfo.tsx
+++ b/frontend/src/components/dashboard/aggregator/components/MemoryRequirementInfo.tsx
@@ -2,25 +2,59 @@
 import { Alert, AlertDescription } from "../../../../components/ui/alert";
 import { Info } from "lucide-react";
 import { calculateMemoryRequirementDetails} from "../utils/modelMemoryCalculator";
-import React from "react";
+import { ModelAnalysis, formatModelSize } from "../utils/modelDefinitionParser";
+import React, { useEffect, useState } from "react";
 
 interface MemoryRequirementInfoProps {
-  modelFileSize: number; // bytes
   participantCount: number;
   safetyFactor?: number;
 }
 
 export const MemoryRequirementInfo = ({ 
-  modelFileSize, 
   participantCount,
   safetyFactor = 1.5
 }: MemoryRequirementInfoProps) => {
-  if (!modelFileSize || modelFileSize === 0) {
-    return null;
+  const [modelAnalysis, setModelAnalysis] = useState<ModelAnalysis | null>(null);
+
+  useEffect(() => {
+    // sessionStorage에서 모델 분석 결과 가져오기
+    const modelAnalysisData = sessionStorage.getItem("modelAnalysis");
+    if (modelAnalysisData) {
+      try {
+        const analysis = JSON.parse(modelAnalysisData);
+        setModelAnalysis(analysis);
+        console.log("MemoryRequirementInfo: 모델 분석 데이터 로드됨", {
+          totalParams: analysis.totalParams,
+          modelSizeBytes: analysis.modelSizeBytes,
+          framework: analysis.framework
+        });
+      } catch (error) {
+        console.error("모델 분석 데이터 파싱 실패:", error);
+      }
+    } else {
+      console.warn("MemoryRequirementInfo: 모델 분석 데이터 없음");
+    }
+  }, []);
+
+  // 모델 분석 결과가 없으면 컴포넌트를 숨김
+  if (!modelAnalysis) {
+    return (
+      <Alert className="mb-4">
+        <Info className="h-4 w-4" />
+        <AlertDescription>
+          <div className="space-y-2">
+            <div className="font-medium text-amber-600">모델 분석 정보 없음</div>
+            <div className="text-sm">
+              모델 정의 파일을 업로드하면 메모리 요구사항을 자동으로 계산합니다.
+            </div>
+          </div>
+        </AlertDescription>
+      </Alert>
+    );
   }
 
   const memoryDetails = calculateMemoryRequirementDetails(
-    modelFileSize,
+    modelAnalysis.modelSizeBytes,
     participantCount,
     safetyFactor
   );
@@ -29,18 +63,53 @@ export const MemoryRequirementInfo = ({
     <Alert className="mb-4">
       <Info className="h-4 w-4" />
       <AlertDescription>
-        <div className="space-y-2">
-          <div className="font-medium">최소 메모리 요구사항 계산</div>
-          <div className="text-sm space-y-1">
-            <div>• 모델 파일 크기: {memoryDetails.modelFileSizeFormatted}</div>
-            <div>• 참여자 수: {memoryDetails.participantCount}명</div>
-            <div>• 안전 계수: {memoryDetails.safetyFactor}배</div>
-            <div className="pt-1 font-medium text-blue-600">
-              → 최소 요구 RAM: {memoryDetails.recommendedMemoryGB}GB
+        <div className="space-y-3">
+          <div className="font-medium">모델 기반 메모리 요구사항</div>
+          
+          <div className="text-sm space-y-2">
+            {/* 모델 정보 */}
+            <div className="bg-gray-50 p-2 rounded space-y-1">
+              <div className="font-medium text-sm">📊 모델 분석 결과</div>
+              <div>• 프레임워크: {modelAnalysis.framework}</div>
+              <div>• 파라미터 수: {formatModelSize(modelAnalysis.totalParams)}</div>
+              <div>• 모델 크기: {memoryDetails.modelSizeFormatted}</div>
             </div>
-            <div className="text-xs text-gray-500">
-              계산식: {memoryDetails.formula}
+
+            {/* 계산 정보 */}
+            <div>
+              <div>• 참여자 수: {memoryDetails.participantCount}명</div>
+              <div>• 안전 계수: {memoryDetails.safetyFactor}배</div>
+              <div className="pt-1 font-medium text-blue-600">
+                → 최소 요구 RAM: {memoryDetails.recommendedMemoryGB}GB
+              </div>
             </div>
+
+            {/* 계산식 */}
+            <div className="text-xs text-gray-500 bg-gray-50 p-2 rounded">
+              <div>계산식: {memoryDetails.formula}</div>
+              {memoryDetails.notes && (
+                <div className="mt-1 text-amber-600">{memoryDetails.notes}</div>
+              )}
+            </div>
+
+            {/* 레이어 정보 (있는 경우) */}
+            {modelAnalysis.layerInfo.length > 0 && (
+              <details className="text-xs">
+                <summary className="cursor-pointer font-medium">주요 레이어 정보</summary>
+                <div className="mt-1 space-y-1 bg-gray-50 p-2 rounded max-h-20 overflow-y-auto">
+                  {modelAnalysis.layerInfo.slice(0, 3).map((layer, idx) => (
+                    <div key={idx}>
+                      • {layer.name}: {layer.params.toLocaleString()} params
+                    </div>
+                  ))}
+                  {modelAnalysis.layerInfo.length > 3 && (
+                    <div className="text-gray-500">
+                      ... 및 {modelAnalysis.layerInfo.length - 3}개 레이어 더
+                    </div>
+                  )}
+                </div>
+              </details>
+            )}
           </div>
         </div>
       </AlertDescription>

--- a/frontend/src/components/dashboard/aggregator/utils/modelDefinitionParser.ts
+++ b/frontend/src/components/dashboard/aggregator/utils/modelDefinitionParser.ts
@@ -1,0 +1,347 @@
+// utils/modelDefinitionParser.ts
+
+export interface ModelAnalysis {
+    totalParams: number;
+    modelSizeBytes: number;
+    layerInfo: {
+      name: string;
+      type: string;
+      params: number;
+    }[];
+    framework: 'pytorch' | 'tensorflow' | 'unknown';
+  }
+  
+  /**
+   * 모델 정의 파일(.py)을 분석하여 대략적인 모델 크기를 추정합니다.
+   * 간단한 정규식 기반 파싱으로 주요 레이어들의 파라미터 수를 계산합니다.
+   */
+  export const analyzeModelDefinition = async (file: File): Promise<ModelAnalysis> => {
+    const content = await file.text();
+    
+    const analysis: ModelAnalysis = {
+      totalParams: 0,
+      modelSizeBytes: 0,
+      layerInfo: [],
+      framework: detectFramework(content)
+    };
+  
+    if (analysis.framework === 'pytorch') {
+      analyzePyTorchModel(content, analysis);
+    } else if (analysis.framework === 'tensorflow') {
+      analyzeTensorFlowModel(content, analysis);
+    } else {
+      // 알 수 없는 프레임워크인 경우 기본값 사용
+      analysis.totalParams = 1000000; // 1M 파라미터 기본값
+    }
+  
+    // 파라미터가 너무 적게 계산된 경우 (transfer learning 등) 최소값 보장
+    if (analysis.totalParams < 100000) {
+      const minParams = estimateMinimumParams(content);
+      analysis.totalParams = Math.max(analysis.totalParams, minParams);
+      
+      if (minParams > analysis.totalParams) {
+        analysis.layerInfo.push({
+          name: 'Estimated additional params',
+          type: 'Estimated',
+          params: minParams - analysis.totalParams
+        });
+      }
+    }
+  
+    // 파라미터 수에서 바이트 크기 계산 (FP32 기준: 4 bytes per parameter)
+    analysis.modelSizeBytes = analysis.totalParams * 4;
+    
+    return analysis;
+  };
+  
+  /**
+   * 모델의 최소 파라미터 수 추정 (변수명, 주석 등 기반)
+   */
+  const estimateMinimumParams = (content: string): number => {
+    // num_classes 추출
+    const numClassesMatch = content.match(/num_classes\s*=\s*(\d+)/);
+    const numClasses = numClassesMatch ? parseInt(numClassesMatch[1]) : 3;
+    
+    // 이미지 크기 관련 정보 추출
+    const hasImageProcessing = content.includes('224') || content.includes('ImageNet') || 
+                              content.includes('Conv2d') || content.includes('AdaptiveAvgPool');
+    
+    // Transfer learning 감지
+    const isTransferLearning = content.includes('pretrained') || content.includes('weights=') ||
+                              content.includes('requires_grad = False') || content.includes('.features');
+    
+    if (isTransferLearning && hasImageProcessing) {
+      // Transfer learning + 이미지: 최소 1M 파라미터
+      return 1000000;
+    } else if (hasImageProcessing) {
+      // 이미지 모델: 최소 500K 파라미터
+      return 500000;
+    } else {
+      // 일반 모델: 클래스 수 기반 추정
+      return Math.max(numClasses * 1000, 100000);
+    }
+  };
+  
+  /**
+   * 프레임워크 감지
+   */
+  const detectFramework = (content: string): 'pytorch' | 'tensorflow' | 'unknown' => {
+    if (content.includes('import torch') || content.includes('nn.Module')) {
+      return 'pytorch';
+    }
+    if (content.includes('tensorflow') || content.includes('keras')) {
+      return 'tensorflow';
+    }
+    return 'unknown';
+  };
+  
+  /**
+   * Pretrained 모델 감지 및 파라미터 수 추정
+   */
+  const detectPretrainedModels = (content: string) => {
+    const pretrainedModels: { name: string; params: number }[] = []; // 타입 정의 추가
+    
+    // VGG 모델들
+    if (content.includes('models.vgg16') || content.includes('vgg16(')) {
+        pretrainedModels.push({
+            name: 'VGG16',
+            params: 138357544 // 약 138M 파라미터
+        });
+    }
+    if (content.includes('models.vgg19') || content.includes('vgg19(')) {
+        pretrainedModels.push({
+            name: 'VGG19',
+            params: 143667240 // 약 144M 파라미터
+        });
+    }
+  
+    // ResNet 모델들
+    if (content.includes('models.resnet18') || content.includes('resnet18(')) {
+      pretrainedModels.push({
+        name: 'ResNet18',
+        params: 11689512 // 약 11.7M 파라미터
+      });
+    }
+    if (content.includes('models.resnet50') || content.includes('resnet50(')) {
+      pretrainedModels.push({
+        name: 'ResNet50',
+        params: 25557032 // 약 25.6M 파라미터
+      });
+    }
+  
+    // EfficientNet 모델들
+    if (content.includes('models.efficientnet_b0') || content.includes('efficientnet_b0(')) {
+      pretrainedModels.push({
+        name: 'EfficientNet-B0',
+        params: 5288548 // 약 5.3M 파라미터
+      });
+    }
+  
+    // BERT 계열 (transformers 라이브러리)
+    if (content.includes('AutoModel') || content.includes('BertModel')) {
+      pretrainedModels.push({
+        name: 'BERT-base',
+        params: 110000000 // 약 110M 파라미터 (기본값)
+      });
+    }
+  
+    // GPT 계열
+    if (content.includes('GPT2') || content.includes('gpt2')) {
+      pretrainedModels.push({
+        name: 'GPT-2',
+        params: 117000000 // 약 117M 파라미터 (base 모델)
+      });
+    }
+  
+    return pretrainedModels;
+  };
+  
+  /**
+   * PyTorch 모델 분석
+   */
+  const analyzePyTorchModel = (content: string, analysis: ModelAnalysis) => {
+    // Pretrained 모델 사용 여부 확인
+    const pretrainedModels = detectPretrainedModels(content);
+    pretrainedModels.forEach(model => {
+      analysis.layerInfo.push({
+        name: `Pretrained ${model.name}`,
+        type: 'Pretrained',
+        params: model.params
+      });
+      analysis.totalParams += model.params;
+    });
+  
+    // Linear/Dense 레이어 찾기 - nn.Linear(in_features, out_features)
+    const linearMatches = content.match(/nn\.Linear\s*\(\s*(\d+)\s*,\s*(\d+)\s*\)/g);
+    if (linearMatches) {
+      linearMatches.forEach(match => {
+        const params = match.match(/(\d+)/g);
+        if (params && params.length >= 2) {
+          const inFeatures = parseInt(params[0]);
+          const outFeatures = parseInt(params[1]);
+          const paramCount = inFeatures * outFeatures + outFeatures; // weights + bias
+          
+          analysis.layerInfo.push({
+            name: `Linear(${inFeatures}, ${outFeatures})`,
+            type: 'Linear',
+            params: paramCount
+          });
+          analysis.totalParams += paramCount;
+        }
+      });
+    }
+  
+    // Sequential 내부의 Linear 레이어들도 찾기
+    const sequentialMatches = content.match(/nn\.Sequential\s*\(([\s\S]*?)\)/g);
+    if (sequentialMatches) {
+      sequentialMatches.forEach(seqMatch => {
+        const innerLinearMatches = seqMatch.match(/nn\.Linear\s*\(\s*(\d+)\s*,\s*(\d+)\s*\)/g);
+        if (innerLinearMatches) {
+          innerLinearMatches.forEach(match => {
+            const params = match.match(/(\d+)/g);
+            if (params && params.length >= 2) {
+              const inFeatures = parseInt(params[0]);
+              const outFeatures = parseInt(params[1]);
+              const paramCount = inFeatures * outFeatures + outFeatures;
+              
+              analysis.layerInfo.push({
+                name: `Linear(${inFeatures}, ${outFeatures})`,
+                type: 'Linear',
+                params: paramCount
+              });
+              analysis.totalParams += paramCount;
+            }
+          });
+        }
+      });
+    }
+  
+    // Conv2d 레이어 찾기 - nn.Conv2d(in_channels, out_channels, kernel_size)
+    const convMatches = content.match(/nn\.Conv2d\s*\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+|\(\d+,\s*\d+\))/g);
+    if (convMatches) {
+      convMatches.forEach(match => {
+        const params = match.match(/(\d+)/g);
+        if (params && params.length >= 3) {
+          const inChannels = parseInt(params[0]);
+          const outChannels = parseInt(params[1]);
+          const kernelSize = parseInt(params[2]);
+          const paramCount = inChannels * outChannels * kernelSize * kernelSize + outChannels;
+          
+          analysis.layerInfo.push({
+            name: `Conv2d(${inChannels}, ${outChannels}, ${kernelSize})`,
+            type: 'Conv2d',
+            params: paramCount
+          });
+          analysis.totalParams += paramCount;
+        }
+      });
+    }
+  
+    // Embedding 레이어 찾기
+    const embeddingMatches = content.match(/nn\.Embedding\s*\(\s*(\d+)\s*,\s*(\d+)\s*\)/g);
+    if (embeddingMatches) {
+      embeddingMatches.forEach(match => {
+        const params = match.match(/(\d+)/g);
+        if (params && params.length >= 2) {
+          const vocabSize = parseInt(params[0]);
+          const embeddingDim = parseInt(params[1]);
+          const paramCount = vocabSize * embeddingDim;
+          
+          analysis.layerInfo.push({
+            name: `Embedding(${vocabSize}, ${embeddingDim})`,
+            type: 'Embedding',
+            params: paramCount
+          });
+          analysis.totalParams += paramCount;
+        }
+      });
+    }
+  };
+  
+  /**
+   * TensorFlow/Keras 모델 분석
+   */
+  const analyzeTensorFlowModel = (content: string, analysis: ModelAnalysis) => {
+    // Dense 레이어 찾기
+    const denseMatches = content.match(/Dense\s*\(\s*(\d+)/g);
+    if (denseMatches) {
+      // 간단한 추정: 각 Dense 레이어가 이전 레이어와 연결되어 있다고 가정
+      let prevSize = 128; // 기본값
+      denseMatches.forEach(match => {
+        const sizeMatch = match.match(/(\d+)/);
+        if (sizeMatch) {
+          const currentSize = parseInt(sizeMatch[1]);
+          const paramCount = prevSize * currentSize + currentSize;
+          
+          analysis.layerInfo.push({
+            name: `Dense(${currentSize})`,
+            type: 'Dense',
+            params: paramCount
+          });
+          analysis.totalParams += paramCount;
+          prevSize = currentSize;
+        }
+      });
+    }
+  
+    // Conv2D 레이어 찾기 (간단한 추정)
+    const conv2dMatches = content.match(/Conv2D\s*\(\s*(\d+)/g);
+    if (conv2dMatches) {
+      conv2dMatches.forEach(match => {
+        const sizeMatch = match.match(/(\d+)/);
+        if (sizeMatch) {
+          const filters = parseInt(sizeMatch[1]);
+          const paramCount = filters * 3 * 3 * 3 + filters; // 3x3 kernel, 3 input channels 가정
+          
+          analysis.layerInfo.push({
+            name: `Conv2D(${filters})`,
+            type: 'Conv2D',
+            params: paramCount
+          });
+          analysis.totalParams += paramCount;
+        }
+      });
+    }
+  };
+  
+  /**
+   * 모델 크기를 사람이 읽기 쉬운 형태로 포맷
+   */
+  export const formatModelSize = (params: number): string => {
+    if (params < 1000) {
+      return `${params} 파라미터`;
+    } else if (params < 1000000) {
+      return `${(params / 1000).toFixed(1)}K 파라미터`;
+    } else if (params < 1000000000) {
+      return `${(params / 1000000).toFixed(1)}M 파라미터`;
+    } else {
+      return `${(params / 1000000000).toFixed(1)}B 파라미터`;
+    }
+  };
+  
+  /**
+   * 기본 모델 크기 추정값들 (파라미터 수)
+   */
+  export const DEFAULT_MODEL_SIZES = {
+    'small': 1000000,      // 1M parameters
+    'medium': 10000000,    // 10M parameters  
+    'large': 100000000,    // 100M parameters
+    'xlarge': 1000000000   // 1B parameters
+  };
+  
+  /**
+   * 모델 정의가 분석되지 않았을 때 사용할 기본값 선택기
+   */
+  export const getDefaultModelSize = (modelType?: string): number => {
+    const type = modelType?.toLowerCase();
+    
+    if (type?.includes('bert') || type?.includes('transformer')) {
+      return DEFAULT_MODEL_SIZES.medium;
+    } else if (type?.includes('resnet') || type?.includes('cnn')) {
+      return DEFAULT_MODEL_SIZES.small;
+    } else if (type?.includes('gpt') || type?.includes('llm')) {
+      return DEFAULT_MODEL_SIZES.large;
+    }
+    
+    return DEFAULT_MODEL_SIZES.small; // 기본값
+  };

--- a/frontend/src/components/dashboard/aggregator/utils/modelMemoryCalculator.ts
+++ b/frontend/src/components/dashboard/aggregator/utils/modelMemoryCalculator.ts
@@ -1,86 +1,150 @@
 // utils/modelMemoryCalculator.ts
 
 /**
- * 모델 파일 크기와 참여자 수를 기반으로 최소 메모리 요구사항을 계산합니다.
- * 
- * @param modelFileSizeInBytes - 모델 파일 크기 (bytes)
- * @param participantCount - 참여자 수
- * @param safetyFactor - 안전 계수 (기본값: 1.5)
- * @returns 최소 메모리 요구사항 (GB)
+ * 모델 정의 측정 결과(파라미터 수 기반)로부터
+ * 최소 메모리 요구사항을 계산하는 유틸.
+ *
+ * 기존: 파일 크기(bytes) 기반 → 폐지(호환 래퍼 유지)
+ * 신규: ModelMeta.fp32_bytes / fp16_bytes / int8_bytes 중 선택
+ */
+
+export type Precision = "fp32" | "fp16" | "int8";
+
+export interface ModelMeta {
+  params: number;
+  buffers: number;
+  total_elements: number;
+  fp32_bytes: number;
+  fp16_bytes: number;
+  int8_bytes: number;
+}
+
+/** Bytes → GB */
+export const bytesToGB = (bytes: number): number => bytes / (1024 ** 3);
+/** Bytes → 사람이 읽기 쉬운 단위 */
+export const formatFileSize = (bytes: number): string => {
+  if (!Number.isFinite(bytes) || bytes <= 0) return "0 Bytes";
+  const k = 1024;
+  const sizes = ["Bytes", "KB", "MB", "GB", "TB"];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  const val = bytes / Math.pow(k, i);
+  return `${Math.round(val * 100) / 100} ${sizes[i]}`;
+};
+
+/** precision에 따른 모델 상태 크기(bytes) 선택 */
+const pickBytesByPrecision = (meta: ModelMeta, precision: Precision): number => {
+  switch (precision) {
+    case "fp16": return meta.fp16_bytes;
+    case "int8": return meta.int8_bytes;
+    case "fp32":
+    default:     return meta.fp32_bytes;
+  }
+};
+
+/**
+ * 신규 API
+ * 모델 정의 측정 메타 + 참여자 수 기반 최소 RAM 요구량(GB) 계산
+ * 공식: ceil( (model_state_bytes * participantCount * safetyFactor) / 1GB )
+ * - 기본 최소값 2GB 보장(시스템/오버헤드)
+ */
+export const calculateMinimumMemoryRequirementFromMeta = (
+  meta: ModelMeta,
+  participantCount: number,
+  safetyFactor: number = 1.5,
+  precision: Precision = "fp32"
+): number => {
+  const perModelBytes = pickBytesByPrecision(meta, precision);
+  const totalBytes = perModelBytes * Math.max(1, participantCount) * safetyFactor;
+  const gb = bytesToGB(totalBytes);
+  const rounded = Math.round(gb * 100) / 100; // 소수점 둘째자리
+  const MIN_SYSTEM_GB = 2;
+  return Math.max(rounded, MIN_SYSTEM_GB);
+};
+
+/** 결과 상세 정보 타입 */
+export interface MemoryRequirementDetails {
+  precision: Precision;
+  participantCount: number;
+  safetyFactor: number;
+  modelSizeBytes: number;
+  modelSizeFormatted: string;
+  calculatedMemoryGB: number;
+  recommendedMemoryGB: number; // 일반 메모리 단계로 올림
+  formula: string;
+  notes?: string;
+}
+
+/** 일반 메모리 단계(필요시 조정) */
+const COMMON_MEMORY_SIZES = [2, 4, 8, 16, 32, 64, 128, 256];
+
+/**
+ * 신규 API (상세)
+ * - 선택 precision 기준 모델 상태 크기와 계산식을 함께 반환
+ */
+export const calculateMemoryRequirementDetailsFromMeta = (
+  meta: ModelMeta,
+  participantCount: number,
+  safetyFactor: number = 1.5,
+  precision: Precision = "fp32"
+): MemoryRequirementDetails => {
+  const modelBytes = pickBytesByPrecision(meta, precision);
+  const calculatedMemoryGB = calculateMinimumMemoryRequirementFromMeta(
+    meta, participantCount, safetyFactor, precision
+  );
+  const recommendedMemoryGB =
+    COMMON_MEMORY_SIZES.find(sz => sz >= calculatedMemoryGB) ?? Math.ceil(calculatedMemoryGB);
+
+  return {
+    precision,
+    participantCount,
+    safetyFactor,
+    modelSizeBytes: modelBytes,
+    modelSizeFormatted: formatFileSize(modelBytes),
+    calculatedMemoryGB,
+    recommendedMemoryGB,
+    formula: `ceil( ${formatFileSize(modelBytes)} × ${participantCount} × ${safetyFactor} )`,
+    notes: precision === "fp32"
+      ? "기본값은 FP32 기준입니다. 통신/저장 최적화를 위해 FP16/INT8도 참고하세요."
+      : "혼합정밀/양자화 환경 가정. 프레임워크/런타임 설정에 따라 실제 값이 달라질 수 있습니다.",
+  };
+};
+
+/* ------------------------------ 호환 래퍼 ------------------------------ */
+/**
+ * (구) 파일 크기 기반 API 유지 (내부적으로 FP32 메타로 변환하여 재사용)
+ * 기존 코드가 크게 안 바뀌도록 남겨둡니다.
  */
 export const calculateMinimumMemoryRequirement = (
-    modelFileSizeInBytes: number,
-    participantCount: number,
-    safetyFactor: number = 1.5
-  ): number => {
-    // bytes to GB 변환 (1GB = 1024^3 bytes)
-    const modelFileSizeInGB = modelFileSizeInBytes / (1024 * 1024 * 1024);
-    
-    // 최소 메모리 요구사항 계산
-    // 공식: 모델 크기 * 참여자 수 * 안전 계수
-    const minMemoryGB = modelFileSizeInGB * participantCount * safetyFactor;
-    
-    // 최소 2GB는 보장 (시스템 오버헤드용)
-    const minSystemMemory = 2;
-    
-    // 소수점 둘째자리까지 반올림
-    return Math.max(Math.round(minMemoryGB * 100) / 100, minSystemMemory);
+  modelFileSizeInBytes: number,
+  participantCount: number,
+  safetyFactor: number = 1.5
+): number => {
+  const pseudoMeta: ModelMeta = {
+    params: 0, buffers: 0, total_elements: 0,
+    fp32_bytes: modelFileSizeInBytes,
+    fp16_bytes: Math.floor(modelFileSizeInBytes / 2),
+    int8_bytes: Math.floor(modelFileSizeInBytes / 4),
   };
-  
-  /**
-   * 파일 크기를 읽기 쉬운 형식으로 변환합니다.
-   * 
-   * @param bytes - 바이트 단위 파일 크기
-   * @returns 포맷된 파일 크기 문자열
-   */
-  export const formatFileSize = (bytes: number): string => {
-    if (bytes === 0) return '0 Bytes';
-    
-    const k = 1024;
-    const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
-    const i = Math.floor(Math.log(bytes) / Math.log(k));
-    
-    return Math.round((bytes / Math.pow(k, i)) * 100) / 100 + ' ' + sizes[i];
+  return calculateMinimumMemoryRequirementFromMeta(
+    pseudoMeta, participantCount, safetyFactor, "fp32"
+  );
+};
+
+/**
+ * (구) 상세 API 유지
+ */
+export const calculateMemoryRequirementDetails = (
+  modelFileSizeInBytes: number,
+  participantCount: number,
+  safetyFactor: number = 1.5
+): MemoryRequirementDetails => {
+  const pseudoMeta: ModelMeta = {
+    params: 0, buffers: 0, total_elements: 0,
+    fp32_bytes: modelFileSizeInBytes,
+    fp16_bytes: Math.floor(modelFileSizeInBytes / 2),
+    int8_bytes: Math.floor(modelFileSizeInBytes / 4),
   };
-  
-  /**
-   * 메모리 요구사항 계산 결과를 포함한 상세 정보를 반환합니다.
-   */
-  export interface MemoryRequirementDetails {
-    modelFileSizeBytes: number;
-    modelFileSizeFormatted: string;
-    participantCount: number;
-    safetyFactor: number;
-    calculatedMemoryGB: number;
-    recommendedMemoryGB: number; // 가장 가까운 일반적인 메모리 크기로 반올림
-    formula: string;
-  }
-  
-  /**
-   * 메모리 요구사항에 대한 상세 정보를 계산합니다.
-   */
-  export const calculateMemoryRequirementDetails = (
-    modelFileSizeInBytes: number,
-    participantCount: number,
-    safetyFactor: number = 1.5
-  ): MemoryRequirementDetails => {
-    const calculatedMemoryGB = calculateMinimumMemoryRequirement(
-      modelFileSizeInBytes,
-      participantCount,
-      safetyFactor
-    );
-    
-    // 일반적인 메모리 크기로 반올림 (2, 4, 8, 16, 32, 64, 128, 256 GB)
-    const commonMemorySizes = [2, 4, 8, 16, 32, 64, 128, 256];
-    const recommendedMemoryGB = commonMemorySizes.find(size => size >= calculatedMemoryGB) || calculatedMemoryGB;
-    
-    return {
-      modelFileSizeBytes: modelFileSizeInBytes,
-      modelFileSizeFormatted: formatFileSize(modelFileSizeInBytes),
-      participantCount,
-      safetyFactor,
-      calculatedMemoryGB,
-      recommendedMemoryGB,
-      formula: `(${formatFileSize(modelFileSizeInBytes)} × ${participantCount}명 × ${safetyFactor}) = ${calculatedMemoryGB.toFixed(2)}GB → ${recommendedMemoryGB}GB 권장`
-    };
-  };
+  return calculateMemoryRequirementDetailsFromMeta(
+    pseudoMeta, participantCount, safetyFactor, "fp32"
+  );
+};


### PR DESCRIPTION
## 기존
모델 파일을 업로드 하는 방식이어서 해당 파일의 크기를 바로 제약 사항에 넣을 수 있었습니다. 

## 수정
모델 정의 파일을 업로드하는 방식으로 바뀌어 파일의 크기를 그대로 제약 사항에 넣으면 문제가 발생

## 개선
모델 파일을 업로드하면 즉시 파라미터와 예상 모델의 크기를 보여줍니다. 해당 계산 결과를 그대로 제약 사항에 넣어주면서 기존의 동작을 그대로 수행하도록 개선하였습니다. 

<img width="690" height="368" alt="image" src="https://github.com/user-attachments/assets/d51ef306-5389-483e-9c67-f92a47306d58" />

---

<img width="1550" height="759" alt="image" src="https://github.com/user-attachments/assets/fbc503ff-3833-4f4b-b21e-0e3d8b368629" />

+ 굳이 모델 정의 파일의 크기를 필요로 하지 않을 것 같아 표기에서 제외시켰습니다.