### PR TITLE
♻️ Refactor: simplify call chain.

### DIFF
--- a/backend/handlers/virtual_machine_handler.go
+++ b/backend/handlers/virtual_machine_handler.go
@@ -221,7 +221,7 @@ func (h *VirtualMachineHandler) MonitorVirtualMachine(c *gin.Context) {
 	}
 
 	// OpenStack VM 모니터링
-	monitoringInfo, err := h.openStackService.MonitorSpecificVM(participant, vm)
+	monitoringInfo, err := h.openStackService.GetVMMonitoringInfoWithParticipant(participant, vm.InstanceID)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("VM 모니터링에 실패했습니다: %v", err)})
 		return
@@ -232,7 +232,6 @@ func (h *VirtualMachineHandler) MonitorVirtualMachine(c *gin.Context) {
 	h.vmRepo.Update(vm)
 
 	c.JSON(http.StatusOK, gin.H{"data": monitoringInfo})
-	return
 }
 
 // AssignTaskToVM은 특정 VM에 작업을 할당합니다

--- a/backend/services/virual_machine_service.go
+++ b/backend/services/virual_machine_service.go
@@ -352,12 +352,6 @@ func (s *OpenStackService) ListVMInstances(participant *models.Participant, toke
 	return response.Servers, nil
 }
 
-// MonitorSpecificVM은 특정 VM의 모니터링 정보를 조회합니다 (더 이상 DB에 저장하지 않음)
-func (s *OpenStackService) MonitorSpecificVM(participant *models.Participant, vm *models.VirtualMachine) (*models.VMMonitoringInfo, error) {
-	// participant의 OpenStack endpoint를 사용하여 Prometheus에서 실제 모니터링 데이터를 수집합니다.
-	return s.GetVMMonitoringInfoWithParticipant(participant, vm.InstanceID)
-}
-
 // VM 헬스체크 수행
 func (s *OpenStackService) HealthCheckSpecificVM(participant *models.Participant, vm *models.VirtualMachine) (*VMHealthCheckResult, error) {
 	startTime := time.Now()


### PR DESCRIPTION
## 수정사항

기존: 복잡한 호출 체인

```plantext
MonitorSpecificVM -> GetVMMonitoringInfoWithParticipant -> getVMIPAddress 
```

수정후: 호출 체인 간소화

```plantext
GetVMMonitoringInfoWithParticipant -> getVMIPAddress 
```

