### PR TITLE
🐛 fix: 집계자 삭제 시 외래 키 제약 조건 오류 해결

### DIFF
--- a/backend/models/aggregator.go
+++ b/backend/models/aggregator.go
@@ -73,7 +73,7 @@ type TrainingRound struct {
 	CreatedAt         time.Time   `json:"created_at" gorm:"autoCreateTime"` // 삭제?
 
 	// Relationships
-	Aggregator *Aggregator `json:"aggregator,omitempty" gorm:"foreignKey:AggregatorID"`
+	Aggregator *Aggregator `json:"aggregator,omitempty" gorm:"foreignKey:AggregatorID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE"`
 }
 
 type ModelMetric struct {


### PR DESCRIPTION
- training_rounds 관련 데이터를 먼저 삭제하도록 트랜잭션 로직 추가
- TrainingRound 모델에 CASCADE 삭제 제약 조건 추가
- import 순서 정리